### PR TITLE
Don't prompt to replace duplicate files in buildpacks

### DIFF
--- a/cutlass/docker.go
+++ b/cutlass/docker.go
@@ -77,7 +77,7 @@ func dockerfile(fixture_path, buildpack_path string, envs []string, network_comm
 		"ADD " + buildpack_path + " /tmp/\n" +
 		"RUN mkdir -p /buildpack\n" +
 		"RUN mkdir -p /tmp/cache\n" +
-		"RUN unzip /tmp/" + filepath.Base(buildpack_path) + " -d /buildpack\n" +
+		"RUN unzip -o /tmp/" + filepath.Base(buildpack_path) + " -d /buildpack\n" +
 		"# HACK around https://github.com/dotcloud/docker/issues/5490\n" +
 		"RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump\n" +
 		"RUN " + network_command + "\n"


### PR DESCRIPTION
In a multistack manifest file, the same dependency can be listed more than once. The code that creates the zip file make no effort to avoid adding them multiple times (https://github.com/cloudfoundry/libbuildpack/blob/master/packager/packager.go#L223)

At extraction time (e.g. when running integration tests for the cached buildpack) the unzip command fails to complete because it prompts the user for the overwrite.

All files have checksums so the overwrite should do nothing more than replacing a file with the same one. Maybe a better solution would be to not include the same file multiple times and spare the disk space. That might be trickier to achieve though since the zip library doesn't seem to support it.