### PR TITLE
Don't add duplicate files in the buildpack zip.

### DIFF
--- a/packager/fixtures/good/manifest.yml
+++ b/packager/fixtures/good/manifest.yml
@@ -11,6 +11,12 @@ dependencies:
   uri: https://www.ietf.org/rfc/rfc2324.txt
   cf_stacks:
   - cflinuxfs2
+- name: ruby
+  version: 1.2.3
+  sha256: b11329c3fd6dbe9dddcb8dd90f18a4bf441858a6b5bfaccae5f91e5c7d2b3596
+  uri: https://www.ietf.org/rfc/rfc2324.txt
+  cf_stacks:
+  - opensuse42
 include_files:
 - manifest.yml
 - VERSION

--- a/packager/packager.go
+++ b/packager/packager.go
@@ -229,8 +229,17 @@ func ZipFiles(filename string, files []File) error {
 	zipWriter := zip.NewWriter(newfile)
 	defer zipWriter.Close()
 
-	// Add files to zip
+	uniqueFileNamesMap := make(map[string]bool)
+	filesSet := []File{}
 	for _, file := range files {
+		if _, exists := uniqueFileNamesMap[file.Name]; !exists {
+			uniqueFileNamesMap[file.Name] = true
+			filesSet = append(filesSet, file)
+		}
+	}
+
+	// Add files to zip
+	for _, file := range filesSet {
 
 		zipfile, err := os.Open(file.Path)
 		if err != nil {

--- a/packager/packager_suite_test.go
+++ b/packager/packager_suite_test.go
@@ -23,6 +23,23 @@ var _ = BeforeSuite(func() {
 	packager.Stderr = GinkgoWriter
 })
 
+// Returns the list of files in a zip archive.
+func ZipFiles(zipFile string) []string {
+	r, err := zip.OpenReader(zipFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer r.Close()
+
+	filePaths := make([]string, 0, len(r.File))
+
+	for _, f := range r.File {
+		filePaths = append(filePaths, f.Name)
+	}
+
+	return filePaths
+}
+
 func ZipContents(zipFile, file string) (string, error) {
 	r, err := zip.OpenReader(zipFile)
 	if err != nil {

--- a/packager/packager_test.go
+++ b/packager/packager_test.go
@@ -104,6 +104,23 @@ var _ = Describe("Packager", func() {
 				Expect(ZipContents(zipFile, "bin/filename")).To(Equal("awesome content"))
 			})
 
+			It("does not contain the same file more than once", func() {
+				files := ZipFiles(zipFile)
+				filesCount := make(map[string]int)
+
+				duplicatesExist := false
+				for _, f := range files {
+					if _, exists := filesCount[f]; exists {
+						duplicatesExist = true
+						break
+					} else {
+						filesCount[f] = 1
+					}
+				}
+
+				Expect(duplicatesExist).To(Equal(false))
+			})
+
 			It("overrides VERSION", func() {
 				Expect(ZipContents(zipFile, "VERSION")).To(Equal(version))
 			})

--- a/packager/summary_test.go
+++ b/packager/summary_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Packager", func() {
 | name | version | cf_stacks |
 |-|-|-|
 | ruby | 1.2.3 | cflinuxfs2 |
+| ruby | 1.2.3 | opensuse42 |
 
 Default binary versions:
 


### PR DESCRIPTION
zip files permit that but it prompts the user to overwrite during zip extraction.

This is an alternative to this: https://github.com/cloudfoundry/libbuildpack/pull/7