### PR TITLE
 Improve scaffold versions of cli/main.go 

### DIFF
--- a/packager/scaffold/scripts/install_go.sh
+++ b/packager/scaffold/scripts/install_go.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-GO_VERSION="1.9.1"
+GO_VERSION="1.10"
 export GoInstallDir="/tmp/go$GO_VERSION"
 mkdir -p $GoInstallDir
 
 if [ ! -f $GoInstallDir/go/bin/go ]; then
-GO_MD5="0571886e9b9ba07773b542a11e9859a4"
-URL=https://buildpacks.cloudfoundry.org/dependencies/go/go${GO_VERSION}.linux-amd64-${GO_MD5:0:8}.tar.gz
+GO_SHA256="244200952f414e9ae6269d32569722a7cd88435f5c52d488cd9599b8bfa1498b"
+URL=https://buildpacks.cloudfoundry.org/dependencies/go/go${GO_VERSION}.linux-amd64-${GO_SHA256:0:8}.tar.gz
 
 echo "-----> Download go ${GO_VERSION}"
 curl -s -L --retry 15 --retry-delay 2 $URL -o /tmp/go.tar.gz
 
-DOWNLOAD_MD5=$(md5sum /tmp/go.tar.gz | cut -d ' ' -f 1)
-if [[ $DOWNLOAD_MD5 != $GO_MD5 ]]; then
-echo "       **ERROR** MD5 mismatch: got $DOWNLOAD_MD5 expected $GO_MD5"
+DOWNLOAD_SHA256=$(shasum -a256 /tmp/go.tar.gz | cut -d ' ' -f 1)
+if [[ $DOWNLOAD_SHA256 != $GO_SHA256 ]]; then
+echo "       **ERROR** SHA256 mismatch: got $DOWNLOAD_SHA256 expected $GO_SHA256"
 exit 1
 fi
 

--- a/packager/scaffold/src/LANGUAGE/finalize/cli/main.go
+++ b/packager/scaffold/src/LANGUAGE/finalize/cli/main.go
@@ -1,12 +1,61 @@
 package main
 
-// "LANGUAGE/finalize"
+import (
+	"LANGUAGE/finalize"
+	_ "LANGUAGE/hooks"
+	"os"
+	"time"
 
-//TODO: jf&vh Scaffold itself does not need to compile.
+	"github.com/cloudfoundry/libbuildpack"
+)
+
 func main() {
-	// TODO: Call finalize.Run here
-	// err = finalize.Run(&s)
-	// if err != nil {
-	// 	os.Exit(1)
-	// }
+	logger := libbuildpack.NewLogger(os.Stdout)
+
+	buildpackDir, err := libbuildpack.GetBuildpackDir()
+	if err != nil {
+		logger.Error("Unable to determine buildpack directory: %s", err.Error())
+		os.Exit(9)
+	}
+
+	manifest, err := libbuildpack.NewManifest(buildpackDir, logger, time.Now())
+	if err != nil {
+		logger.Error("Unable to load buildpack manifest: %s", err.Error())
+		os.Exit(10)
+	}
+
+	stager := libbuildpack.NewStager(os.Args[1:], logger, manifest)
+
+	if err = manifest.ApplyOverride(stager.DepsDir()); err != nil {
+		logger.Error("Unable to apply override.yml files: %s", err)
+		os.Exit(17)
+	}
+
+	if err := stager.SetStagingEnvironment(); err != nil {
+		logger.Error("Unable to setup environment variables: %s", err.Error())
+		os.Exit(11)
+	}
+
+	f := finalize.Finalizer{
+		Manifest: manifest,
+		Stager:   stager,
+		Command:  &libbuildpack.Command{},
+		Log:      logger,
+	}
+
+	if err := f.Run(); err != nil {
+		os.Exit(12)
+	}
+
+	if err := libbuildpack.RunAfterCompile(stager); err != nil {
+		logger.Error("After Compile: %s", err.Error())
+		os.Exit(13)
+	}
+
+	if err := stager.SetLaunchEnvironment(); err != nil {
+		logger.Error("Unable to setup launch environment: %s", err.Error())
+		os.Exit(14)
+	}
+
+	stager.StagingComplete()
 }

--- a/packager/scaffold/src/LANGUAGE/hooks/hooks_debug.go
+++ b/packager/scaffold/src/LANGUAGE/hooks/hooks_debug.go
@@ -1,0 +1,33 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cloudfoundry/libbuildpack"
+)
+
+type hooks1 struct {
+	libbuildpack.DefaultHook
+}
+
+type hooks2 struct {
+	libbuildpack.DefaultHook
+}
+
+func init() {
+	if os.Getenv("BP_DEBUG") != "" {
+		libbuildpack.AddHook(hooks1{})
+		libbuildpack.AddHook(hooks2{})
+	}
+}
+
+func (h hooks1) BeforeCompile(compiler *libbuildpack.Stager) error {
+	fmt.Println("HOOKS 1: BeforeCompile")
+	return nil
+}
+
+func (h hooks2) AfterCompile(compiler *libbuildpack.Stager) error {
+	fmt.Println("HOOKS 2: AfterCompile")
+	return nil
+}

--- a/packager/scaffold/src/LANGUAGE/supply/cli/main.go
+++ b/packager/scaffold/src/LANGUAGE/supply/cli/main.go
@@ -1,12 +1,83 @@
 package main
 
-// "LANGUAGE/supply"
+import (
+	_ "LANGUAGE/hooks"
+	"LANGUAGE/supply"
+	"os"
+	"path/filepath"
+	"time"
 
-//TODO: jf&vh Scaffold itself does not need to compile.
+	"github.com/cloudfoundry/libbuildpack"
+)
+
 func main() {
-	// TODO: Call supply.Run here
-	// err = supply.Run(&s)
-	// if err != nil {
-	// 	os.Exit(1)
-	// }
+	logger := libbuildpack.NewLogger(os.Stdout)
+
+	buildpackDir, err := libbuildpack.GetBuildpackDir()
+	if err != nil {
+		logger.Error("Unable to determine buildpack directory: %s", err.Error())
+		os.Exit(9)
+	}
+
+	manifest, err := libbuildpack.NewManifest(buildpackDir, logger, time.Now())
+	if err != nil {
+		logger.Error("Unable to load buildpack manifest: %s", err.Error())
+		os.Exit(10)
+	}
+
+	stager := libbuildpack.NewStager(os.Args[1:], logger, manifest)
+	if err := stager.CheckBuildpackValid(); err != nil {
+		os.Exit(11)
+	}
+
+	os.MkdirAll(filepath.Join(stager.DepDir(), "bin"), 0755)
+	os.MkdirAll(filepath.Join(stager.DepDir(), "lib"), 0755)
+
+	if err = manifest.SetAppCacheDir(stager.CacheDir()); err != nil {
+		logger.Error("Unable to setup app cache dir: %s", err)
+		os.Exit(18)
+	}
+	if err = manifest.ApplyOverride(stager.DepsDir()); err != nil {
+		logger.Error("Unable to apply override.yml files: %s", err)
+		os.Exit(17)
+	}
+
+	err = libbuildpack.RunBeforeCompile(stager)
+	if err != nil {
+		logger.Error("Before Compile: %s", err.Error())
+		os.Exit(12)
+	}
+
+	if err := os.MkdirAll(filepath.Join(stager.DepDir(), "bin"), 0755); err != nil {
+		logger.Error("Unable to create bin directory: %s", err.Error())
+		os.Exit(13)
+	}
+
+	err = stager.SetStagingEnvironment()
+	if err != nil {
+		logger.Error("Unable to setup environment variables: %s", err.Error())
+		os.Exit(14)
+	}
+
+	s := supply.Supplier{
+		Manifest: manifest,
+		Stager:   stager,
+		Command:  &libbuildpack.Command{},
+		Log:      logger,
+	}
+
+	err = s.Run()
+	if err != nil {
+		logger.Error("Error: %s", err)
+		os.Exit(15)
+	}
+
+	if err := stager.WriteConfigYml(nil); err != nil {
+		logger.Error("Error writing config.yml: %s", err.Error())
+		os.Exit(16)
+	}
+	if err = manifest.CleanupAppCache(); err != nil {
+		logger.Error("Unable to apply override.yml files: %s", err)
+		os.Exit(19)
+	}
 }


### PR DESCRIPTION
The code in supply/cli/main.go and finalize/cli/main.go was overly simplified. I believe this version gives a better starting point for users.