### PR TITLE
Support a proxy in brats for servers that don't support basic auth.

### DIFF
--- a/bratshelper/tests.go
+++ b/bratshelper/tests.go
@@ -196,14 +196,33 @@ func StagingWithADepThatIsNotTheLatest(depName string, copyBrats func(string) *c
 func StagingWithCustomBuildpackWithCredentialsInDependencies(depRegexp string, copyBrats func(string) *cutlass.App) {
 	Describe("staging with custom buildpack that uses credentials in manifest dependency uris", func() {
 		var (
-			buildpackFile, bpName, stack string
-			app                          *cutlass.App
+			buildpackFile, bpName, stack, username, password string
+			app                                              *cutlass.App
 		)
 		JustBeforeEach(func() {
 			file, err := ModifyBuildpackManifest(buildpackFile, func(m *Manifest) {
 				for _, d := range m.Dependencies {
 					uri, err := url.Parse(d.URI)
-					uri.User = url.UserPassword("login", "password")
+					if proxyHost, ok := os.LookupEnv("PROXY_HOST"); ok {
+						uri.Host = proxyHost
+					}
+					if proxyPort, ok := os.LookupEnv("PROXY_PORT"); ok {
+						uri.Host += ":" + proxyPort
+					}
+					if proxyScheme, ok := os.LookupEnv("PROXY_SCHEME"); ok {
+						uri.Scheme = proxyScheme
+					}
+					if proxyUsername, ok := os.LookupEnv("PROXY_USERNAME"); ok {
+						username = proxyUsername
+					} else {
+						username = "login"
+					}
+					if proxyPassword, ok := os.LookupEnv("PROXY_PASSWORD"); ok {
+						password = proxyPassword
+					} else {
+						password = "password"
+					}
+					uri.User = url.UserPassword(username, password)
 					Expect(err).ToNot(HaveOccurred())
 					d.URI = uri.String()
 				}
@@ -236,8 +255,8 @@ func StagingWithCustomBuildpackWithCredentialsInDependencies(depRegexp string, c
 			})
 			It("does not include credentials in logged dependency uris", func() {
 				Expect(app.Stdout.String()).To(MatchRegexp(depRegexp))
-				Expect(app.Stdout.String()).ToNot(ContainSubstring("login"))
-				Expect(app.Stdout.String()).ToNot(ContainSubstring("password"))
+				Expect(app.Stdout.String()).ToNot(ContainSubstring(username))
+				Expect(app.Stdout.String()).ToNot(ContainSubstring(password))
 			})
 		})
 		Context("using a cached buildpack", func() {
@@ -246,8 +265,8 @@ func StagingWithCustomBuildpackWithCredentialsInDependencies(depRegexp string, c
 			})
 			It("does not include credentials in logged dependency file paths", func() {
 				Expect(app.Stdout.String()).To(MatchRegexp(depRegexp))
-				Expect(app.Stdout.String()).ToNot(ContainSubstring("login"))
-				Expect(app.Stdout.String()).ToNot(ContainSubstring("password"))
+				Expect(app.Stdout.String()).ToNot(ContainSubstring(username))
+				Expect(app.Stdout.String()).ToNot(ContainSubstring(password))
 			})
 		})
 	})


### PR DESCRIPTION
Resolves this issue:
https://github.com/cloudfoundry/libbuildpack/issues/8#issuecomment-377952779

Example of a proxy that can be used:

$ docker run -d  --rm --name nginx-basic-auth-proxy \
  -p 8080:80 \
  -p 8090:8090 \
  -e BASIC_AUTH_USERNAME=username \
  -e BASIC_AUTH_PASSWORD=password \
  -e PROXY_PASS=https://s3.amazonaws.com/ \
  -e SERVER_NAME=127.0.0.1.xip.io \
  -e PORT=80 \
  quay.io/dtan4/nginx-basic-auth-proxy

$ curl http://username:password@127.0.0.1:8080/cf-opensusefs2/dependencies/ruby/ruby-2.4.4-linux-x64-4b9ae741.tgz -o ruby.tar

Signed-off-by: Christian Richter <crichter@suse.com>