### PR TITLE
Don't try to match the dependency file name

### DIFF
--- a/bratshelper/tests.go
+++ b/bratshelper/tests.go
@@ -193,7 +193,7 @@ func StagingWithADepThatIsNotTheLatest(depName string, copyBrats func(string) *c
 	StagingWithADepThatIsNotTheLatestConstrained(depName, "x", copyBrats)
 }
 
-func StagingWithCustomBuildpackWithCredentialsInDependencies(depRegexp string, copyBrats func(string) *cutlass.App) {
+func StagingWithCustomBuildpackWithCredentialsInDependencies(copyBrats func(string) *cutlass.App) {
 	Describe("staging with custom buildpack that uses credentials in manifest dependency uris", func() {
 		var (
 			buildpackFile, bpName, stack, username, password string
@@ -254,7 +254,7 @@ func StagingWithCustomBuildpackWithCredentialsInDependencies(depRegexp string, c
 				buildpackFile = Data.UncachedFile
 			})
 			It("does not include credentials in logged dependency uris", func() {
-				Expect(app.Stdout.String()).To(MatchRegexp(depRegexp))
+				Expect(app.Stdout.String()).To(MatchRegexp(`\[.*-redacted-:-redacted-.*\]`))
 				Expect(app.Stdout.String()).ToNot(ContainSubstring(username))
 				Expect(app.Stdout.String()).ToNot(ContainSubstring(password))
 			})


### PR DESCRIPTION
The test is only trying to make sure that at least one dependency was
installed (and the credentials were redacted) and that the credentials
are nowhere to be found in the output.

This change achieved that without the need to match a specific
dependency filename. This makes it possible to test buildpacks with
filenames that don't match the upstream naming conventions.

**NOTE**: If this is merged, all the buildpack repositories will need to be updated to not pass the regexp argument. E.g. here: https://github.com/cloudfoundry/ruby-buildpack/blob/master/src/ruby/brats/brats_test.go#L23