### PR TITLE
Update libbuildpack to support multi-buildpack on Windows.

### DIFF
--- a/stager_test.go
+++ b/stager_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/cloudfoundry/libbuildpack"
@@ -85,8 +85,8 @@ var _ = Describe("Stager", func() {
 				Expect(s.BuildDir()).To(Equal("buildDir"))
 				Expect(s.CacheDir()).To(Equal("cacheDir"))
 				Expect(s.DepsIdx()).To(Equal("idx"))
-				Expect(s.DepDir()).To(Equal("depsDir/idx"))
-				Expect(s.ProfileDir()).To(Equal("buildDir/.profile.d"))
+				Expect(s.DepDir()).To(Equal(filepath.Join("depsDir", "idx")))
+				Expect(s.ProfileDir()).To(Equal(filepath.Join("buildDir", ".profile.d")))
 			})
 		})
 
@@ -99,7 +99,7 @@ var _ = Describe("Stager", func() {
 				Expect(s.CacheDir()).To(Equal("cacheDir"))
 				Expect(s.DepsIdx()).To(Equal(""))
 				Expect(s.DepDir()).To(Equal(""))
-				Expect(s.ProfileDir()).To(Equal("buildDir/.profile.d"))
+				Expect(s.ProfileDir()).To(Equal(filepath.Join("buildDir", ".profile.d")))
 			})
 		})
 
@@ -262,13 +262,37 @@ var _ = Describe("Stager", func() {
 
 	Describe("AddBinDependencyLink", func() {
 		It("creates a symlink <depDir>/bin/<name> with the relative path to dest", func() {
-			err := s.AddBinDependencyLink(filepath.Join(depsDir, depsIdx, "some", "long", "path"), "dep")
+			var err error
+			destDir := filepath.Join(depsDir, depsIdx, "some", "long")
+			dest := filepath.Join(destDir, "path")
+
+			/* Windows uses hard links, the file must already exist and
+			* be an actual file (not a directory)
+			 */
+			if runtime.GOOS == "windows" {
+				err = os.MkdirAll(destDir, 0777)
+				Expect(err).To(BeNil())
+				f, err := os.Create(dest)
+				Expect(err).To(BeNil())
+				f.Close()
+			}
+
+			err = s.AddBinDependencyLink(dest, "dep")
 			Expect(err).To(BeNil())
 
-			link, err := os.Readlink(filepath.Join(s.DepDir(), "bin", "dep"))
-			Expect(err).To(BeNil())
+			linkSource := filepath.Join(s.DepDir(), "bin", "dep")
 
-			Expect(link).To(Equal("../some/long/path"))
+			if runtime.GOOS == "windows" {
+				f1, err := os.Stat(linkSource)
+				Expect(err).To(BeNil())
+				f2, err := os.Stat(dest)
+				Expect(err).To(BeNil())
+				Expect(os.SameFile(f1, f2)).To(BeTrue())
+			} else {
+				link, err := os.Readlink(linkSource)
+				Expect(link).To(Equal(filepath.Join("..", "some", "long", "path")))
+				Expect(err).To(BeNil())
+			}
 		})
 	})
 
@@ -297,7 +321,7 @@ var _ = Describe("Stager", func() {
 
 			link, err := os.Readlink(filepath.Join(s.DepDir(), "include", "thing1"))
 			Expect(err).To(BeNil())
-			Expect(link).To(Equal("../../../" + path.Base(destDir) + "/thing1"))
+			Expect(link).To(Equal(filepath.Join("..", "..", "..", filepath.Base(destDir), "thing1")))
 
 			data, err := ioutil.ReadFile(filepath.Join(s.DepDir(), "include", "thing1"))
 			Expect(err).To(BeNil())
@@ -305,7 +329,7 @@ var _ = Describe("Stager", func() {
 
 			link, err = os.Readlink(filepath.Join(s.DepDir(), "include", "thing2"))
 			Expect(err).To(BeNil())
-			Expect(link).To(Equal("../../../" + path.Base(destDir) + "/thing2"))
+			Expect(link).To(Equal(filepath.Join("..", "..", "..", filepath.Base(destDir), "thing2")))
 
 			data, err = ioutil.ReadFile(filepath.Join(s.DepDir(), "include", "thing2"))
 			Expect(err).To(BeNil())
@@ -321,7 +345,7 @@ var _ = Describe("Stager", func() {
 
 			link, err := os.Readlink(filepath.Join(s.DepDir(), "include", "thing1"))
 			Expect(err).To(BeNil())
-			Expect(link).To(Equal("../../../" + path.Base(destDir) + "/thing1"))
+			Expect(link).To(Equal(filepath.Join("..", "..", "..", filepath.Base(destDir), "thing1")))
 		})
 	})
 
@@ -352,11 +376,13 @@ var _ = Describe("Stager", func() {
 			It("creates the file as an executable", func() {
 				Expect(profileDScript).To(BeAnExistingFile())
 
-				info, err = os.Stat(profileDScript)
-				Expect(err).To(BeNil())
+				if runtime.GOOS != "windows" { // executable file permissions not relevant for Windows
+					info, err = os.Stat(profileDScript)
+					Expect(err).To(BeNil())
 
-				// make sure at least 1 executable bit is set
-				Expect(info.Mode().Perm() & 0111).NotTo(Equal(os.FileMode(0000)))
+					// make sure at least 1 executable bit is set
+					Expect(info.Mode().Perm() & 0111).NotTo(Equal(os.FileMode(0000)))
+				}
 			})
 
 			It("the script has the correct contents", func() {
@@ -458,10 +484,18 @@ var _ = Describe("Stager", func() {
 				Expect(err).To(BeNil())
 
 				newPath := os.Getenv("PATH")
-				Expect(newPath).To(Equal(fmt.Sprintf("%s/01/bin:%s/00/bin:existing_PATH", depsDir, depsDir)))
+				if runtime.GOOS == "windows" {
+					Expect(newPath).To(Equal(fmt.Sprintf("%s\\01\\bin;%s\\00\\bin;existing_PATH", depsDir, depsDir)))
+				} else {
+					Expect(newPath).To(Equal(fmt.Sprintf("%s/01/bin:%s/00/bin:existing_PATH", depsDir, depsDir)))
+				}
 			})
 
 			It("sets LD_LIBRARY_PATH based on the supplied deps", func() {
+				if runtime.GOOS == "windows" {
+					Skip("We don't use LD_LIBRARY_PATH on Windows.")
+				}
+
 				err = s.SetStagingEnvironment()
 				Expect(err).To(BeNil())
 
@@ -470,6 +504,10 @@ var _ = Describe("Stager", func() {
 			})
 
 			It("sets LIBRARY_PATH based on the supplied deps", func() {
+				if runtime.GOOS == "windows" {
+					Skip("We don't use LIBRARY_PATH on Windows.")
+				}
+
 				err = s.SetStagingEnvironment()
 				Expect(err).To(BeNil())
 
@@ -478,6 +516,10 @@ var _ = Describe("Stager", func() {
 			})
 
 			It("sets CPATH based on the supplied deps", func() {
+				if runtime.GOOS == "windows" {
+					Skip("We don't use CPATH on Windows.")
+				}
+
 				err = s.SetStagingEnvironment()
 				Expect(err).To(BeNil())
 
@@ -486,6 +528,10 @@ var _ = Describe("Stager", func() {
 			})
 
 			It("sets PKG_CONFIG_PATH based on the supplied deps", func() {
+				if runtime.GOOS == "windows" {
+					Skip("We don't use PKG_CONFIG_PATH on Windows.")
+				}
+
 				err = s.SetStagingEnvironment()
 				Expect(err).To(BeNil())
 
@@ -513,10 +559,17 @@ var _ = Describe("Stager", func() {
 					Expect(err).To(BeNil())
 
 					newPath := os.Getenv("PATH")
-					Expect(newPath).To(Equal(fmt.Sprintf("%s/01/bin:%s/00/bin", depsDir, depsDir)))
+					if runtime.GOOS == "windows" {
+						Expect(newPath).To(Equal(fmt.Sprintf("%s\\01\\bin;%s\\00\\bin", depsDir, depsDir)))
+					} else {
+						Expect(newPath).To(Equal(fmt.Sprintf("%s/01/bin:%s/00/bin", depsDir, depsDir)))
+					}
 				})
 
 				It("sets LD_LIBRARY_PATH based on the supplied deps", func() {
+					if runtime.GOOS == "windows" {
+						Skip("We don't use LD_LIBRARY_PATH on Windows.")
+					}
 					err = s.SetStagingEnvironment()
 					Expect(err).To(BeNil())
 
@@ -525,6 +578,9 @@ var _ = Describe("Stager", func() {
 				})
 
 				It("sets LIBRARY_PATH based on the supplied deps", func() {
+					if runtime.GOOS == "windows" {
+						Skip("We don't use LIBRARY_PATH on Windows.")
+					}
 					err = s.SetStagingEnvironment()
 					Expect(err).To(BeNil())
 
@@ -533,6 +589,9 @@ var _ = Describe("Stager", func() {
 				})
 
 				It("sets CPATH based on the supplied deps", func() {
+					if runtime.GOOS == "windows" {
+						Skip("We don't use CPATH on Windows.")
+					}
 					err = s.SetStagingEnvironment()
 					Expect(err).To(BeNil())
 
@@ -541,6 +600,9 @@ var _ = Describe("Stager", func() {
 				})
 
 				It("sets PKG_CONFIG_PATH based on the supplied deps", func() {
+					if runtime.GOOS == "windows" {
+						Skip("We don't use PKG_CONFIG_PATH on Windows.")
+					}
 					err = s.SetStagingEnvironment()
 					Expect(err).To(BeNil())
 
@@ -555,12 +617,17 @@ var _ = Describe("Stager", func() {
 				err = s.SetLaunchEnvironment()
 				Expect(err).To(BeNil())
 
-				contents, err := ioutil.ReadFile(filepath.Join(profileDir, "000_multi-supply.sh"))
-				Expect(err).To(BeNil())
-
-				Expect(string(contents)).To(ContainSubstring(`export PATH=$DEPS_DIR/01/bin:$DEPS_DIR/00/bin$([[ ! -z "${PATH:-}" ]] && echo ":$PATH")`))
-				Expect(string(contents)).To(ContainSubstring(`export LD_LIBRARY_PATH=$DEPS_DIR/02/lib:$DEPS_DIR/01/lib$([[ ! -z "${LD_LIBRARY_PATH:-}" ]] && echo ":$LD_LIBRARY_PATH")`))
-				Expect(string(contents)).To(ContainSubstring(`export LIBRARY_PATH=$DEPS_DIR/02/lib:$DEPS_DIR/01/lib$([[ ! -z "${LIBRARY_PATH:-}" ]] && echo ":$LIBRARY_PATH")`))
+				if runtime.GOOS == "windows" {
+					contents, err := ioutil.ReadFile(filepath.Join(profileDir, "000_multi-supply.bat"))
+					Expect(err).To(BeNil())
+					Expect(string(contents)).To(ContainSubstring(`set PATH=%DEPS_DIR%\01\bin;%DEPS_DIR%\00\bin;%PATH%`))
+				} else {
+					contents, err := ioutil.ReadFile(filepath.Join(profileDir, "000_multi-supply.sh"))
+					Expect(err).To(BeNil())
+					Expect(string(contents)).To(ContainSubstring(`export LIBRARY_PATH=$DEPS_DIR/02/lib:$DEPS_DIR/01/lib$([[ ! -z "${LIBRARY_PATH:-}" ]] && echo ":$LIBRARY_PATH")`))
+					Expect(string(contents)).To(ContainSubstring(`export LD_LIBRARY_PATH=$DEPS_DIR/02/lib:$DEPS_DIR/01/lib$([[ ! -z "${LD_LIBRARY_PATH:-}" ]] && echo ":$LD_LIBRARY_PATH")`))
+					Expect(string(contents)).To(ContainSubstring(`export LIBRARY_PATH=$DEPS_DIR/02/lib:$DEPS_DIR/01/lib$([[ ! -z "${LIBRARY_PATH:-}" ]] && echo ":$LIBRARY_PATH")`))
+				}
 			})
 
 			It("copies scripts from <deps-dir>/<idx>/profile.d to the .profile.d directory, prepending <idx>", func() {

--- a/stager_test.go
+++ b/stager_test.go
@@ -290,8 +290,8 @@ var _ = Describe("Stager", func() {
 				Expect(os.SameFile(f1, f2)).To(BeTrue())
 			} else {
 				link, err := os.Readlink(linkSource)
-				Expect(link).To(Equal(filepath.Join("..", "some", "long", "path")))
 				Expect(err).To(BeNil())
+				Expect(link).To(Equal(filepath.Join("..", "some", "long", "path")))
 			}
 		})
 	})

--- a/stager_unix.go
+++ b/stager_unix.go
@@ -1,0 +1,44 @@
+// +build !windows
+
+package libbuildpack
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const (
+	envPathSeparator   = ":"
+	depsDirEnvVar      = "$DEPS_DIR"
+	scriptName         = "000_multi-supply.sh"
+	scriptLineTemplate = `export %[1]s=%[2]s$([[ ! -z "${%[1]s:-}" ]] && echo ":$%[1]s")`
+)
+
+var stagingEnvVarDirs = map[string]string{
+	"PATH":            "bin",
+	"LD_LIBRARY_PATH": "lib",
+	"LIBRARY_PATH":    "lib",
+	"CPATH":           "include",
+	"PKG_CONFIG_PATH": "pkgconfig",
+}
+
+var launchEnvVarDirs = map[string]string{
+	"PATH":            "bin",
+	"LD_LIBRARY_PATH": "lib",
+	"LIBRARY_PATH":    "lib",
+}
+
+func (s *Stager) AddBinDependencyLink(destPath, sourceName string) error {
+	binDir := filepath.Join(s.DepDir(), "bin")
+
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return err
+	}
+
+	relPath, err := filepath.Rel(binDir, destPath)
+	if err != nil {
+		return err
+	}
+
+	return os.Symlink(relPath, filepath.Join(binDir, sourceName))
+}

--- a/stager_windows.go
+++ b/stager_windows.go
@@ -1,0 +1,33 @@
+// +build windows
+
+package libbuildpack
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const (
+	envPathSeparator   = ";"
+	depsDirEnvVar      = "%DEPS_DIR%"
+	scriptName         = "000_multi-supply.bat"
+	scriptLineTemplate = `set %[1]s=%[2]s;%%%[1]s%%`
+)
+
+var stagingEnvVarDirs = map[string]string{
+	"PATH": "bin",
+}
+
+var launchEnvVarDirs = map[string]string{
+	"PATH": "bin",
+}
+
+func (s *Stager) AddBinDependencyLink(destPath, sourceName string) error {
+	binDir := filepath.Join(s.DepDir(), "bin")
+
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return err
+	}
+
+	return os.Link(destPath, filepath.Join(binDir, sourceName))
+}

--- a/umask_unix_test.go
+++ b/umask_unix_test.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package libbuildpack_test
+
+import "syscall"
+
+func umask(newmask int) (oldmask int) {
+	return syscall.Umask(newmask)
+}

--- a/umask_windows_test.go
+++ b/umask_windows_test.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package libbuildpack_test
+
+func umask(newmask int) (oldmask int) {
+	return 0
+}

--- a/util_test.go
+++ b/util_test.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"syscall"
+	"runtime"
 
 	"github.com/cloudfoundry/libbuildpack"
 	. "github.com/onsi/ginkgo"
@@ -12,6 +12,8 @@ import (
 )
 
 var _ = Describe("Util", func() {
+	const windowsFileModeWarning = "Windows does not respect file mode bits as Linux does, see https://golang.org/pkg/os/#Chmod"
+
 	Describe("ExtractZip", func() {
 		var (
 			tmpdir   string
@@ -42,6 +44,10 @@ var _ = Describe("Util", func() {
 			})
 
 			It("preserves the file mode", func() {
+				if runtime.GOOS == "windows" {
+					Skip(windowsFileModeWarning)
+				}
+
 				err = libbuildpack.ExtractZip("fixtures/thing.zip", tmpdir)
 				Expect(err).To(BeNil())
 
@@ -141,6 +147,10 @@ var _ = Describe("Util", func() {
 				Expect(ioutil.ReadFile(filepath.Join(tmpdir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
 			})
 			It("preserves the file mode", func() {
+				if runtime.GOOS == "windows" {
+					Skip(windowsFileModeWarning)
+				}
+
 				err = libbuildpack.ExtractTarGz("fixtures/thing.tgz", tmpdir)
 				Expect(err).To(BeNil())
 
@@ -201,11 +211,12 @@ var _ = Describe("Util", func() {
 			Expect(err).To(BeNil())
 			defer fh.Close()
 
-			err = fh.Chmod(0742)
-			Expect(err).To(BeNil())
+			if runtime.GOOS != "windows" {
+				err = fh.Chmod(0742)
+				Expect(err).To(BeNil())
+			}
 
-			oldUmask = syscall.Umask(0000)
-
+			oldUmask = umask(0000)
 		})
 		AfterEach(func() {
 			var fh *os.File
@@ -215,13 +226,15 @@ var _ = Describe("Util", func() {
 			Expect(err).To(BeNil())
 			defer fh.Close()
 
-			err = fh.Chmod(oldMode)
-			Expect(err).To(BeNil())
+			if runtime.GOOS != "windows" {
+				err = fh.Chmod(oldMode)
+				Expect(err).To(BeNil())
+			}
 
 			err = os.RemoveAll(tmpdir)
 			Expect(err).To(BeNil())
 
-			syscall.Umask(oldUmask)
+			umask(oldUmask)
 		})
 
 		Context("with a valid source file", func() {
@@ -234,6 +247,10 @@ var _ = Describe("Util", func() {
 			})
 
 			It("preserves the file mode", func() {
+				if runtime.GOOS == "windows" {
+					Skip(windowsFileModeWarning)
+				}
+
 				err = libbuildpack.CopyFile("fixtures/source.txt", filepath.Join(tmpdir, "out.txt"))
 				Expect(err).To(BeNil())
 
@@ -276,6 +293,10 @@ var _ = Describe("Util", func() {
 		})
 
 		It("handles symlink to directory", func() {
+			if runtime.GOOS == "windows" {
+				Skip("Symlinks require administrator privileges on windows and are not used")
+			}
+
 			srcDir := filepath.Join("fixtures", "copydir_symlinks")
 			err = libbuildpack.CopyDirectory(srcDir, destDir)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
Note, the libbuildpack test suite is passing but the checksum, packager, and snapshot tests contain failing tests when run on Windows, which we do not believe are relevant to the added functionality. We'd like to tackle these packages separately.

- Update stager SetStagingEnvironment and SetLaunchEnvironment to use
  Windows paths
- AddBinDepLink: Use hardlinks on windows

  Windows does not support using Symlinks when unless run
  as admin. Also, cannot hardlink directories on windows

- Skip symlink test on windows

Signed-off-by: Natalie Arellano <narellano@pivotal.io>
Signed-off-by: Arjun Sreedharan <asreedharan@pivotal.io>
Signed-off-by: Micah Young <myoung@pivotal.io>

[#159367078]