### PR TITLE
Don't pass the -s flag when stack is empty

### DIFF
--- a/cutlass/cf.go
+++ b/cutlass/cf.go
@@ -143,14 +143,13 @@ func DeleteBuildpack(language string) error {
 }
 
 func UpdateBuildpack(language, file, stack string) error {
-	var command *exec.Cmd
+	args := []string{fmt.Sprintf("%s_buildpack", language), "-p", file, "--enable"}
 
 	if stack != "" {
-		command = exec.Command("cf", "update-buildpack", fmt.Sprintf("%s_buildpack", language), "-p", file, "--enable", "-s", stack)
-	} else {
-		command = exec.Command("cf", "update-buildpack", fmt.Sprintf("%s_buildpack", language), "-p", file, "--enable")
+		args = append(args, "-s", stack)
 	}
 
+	command := exec.Command("cf update-buildpack", args...)
 	if data, err := command.CombinedOutput(); err != nil {
 		return fmt.Errorf("Failed to update buildpack by running '%s':\n%s\n%v", strings.Join(command.Args, " "), string(data), err)
 	}

--- a/cutlass/cf.go
+++ b/cutlass/cf.go
@@ -143,7 +143,14 @@ func DeleteBuildpack(language string) error {
 }
 
 func UpdateBuildpack(language, file, stack string) error {
-	command := exec.Command("cf", "update-buildpack", fmt.Sprintf("%s_buildpack", language), "-p", file, "--enable", "-s", stack)
+	var command *exec.Cmd
+
+	if stack != "" {
+		command = exec.Command("cf", "update-buildpack", fmt.Sprintf("%s_buildpack", language), "-p", file, "--enable", "-s", stack)
+	} else {
+		command = exec.Command("cf", "update-buildpack", fmt.Sprintf("%s_buildpack", language), "-p", file, "--enable")
+	}
+
 	if data, err := command.CombinedOutput(); err != nil {
 		return fmt.Errorf("Failed to update buildpack by running '%s':\n%s\n%v", strings.Join(command.Args, " "), string(data), err)
 	}


### PR DESCRIPTION
When api version is lower than 2.113.0 the "stack" argument is empty
(https://github.com/cloudfoundry/libbuildpack/blob/master/bratshelper/tests.go#L70).
The UpdateBuildpack shouldn't pass the "-s" flag then because it makes
tests fail with: "Multiple buildpacks named brats_ruby_changing_randomstring_buildpack found."