### PR TITLE
Allow querying buildpack language and version from Stager

### DIFF
--- a/stager.go
+++ b/stager.go
@@ -303,6 +303,14 @@ func (s *Stager) SetLaunchEnvironment() error {
 	return nil
 }
 
+func (s *Stager) BuildpackLanguage() string {
+	return s.manifest.Language()
+}
+
+func (s *Stager) BuildpackVersion() (string, error) {
+	return s.manifest.Version()
+}
+
 func existingDepsDirs(depsDir, subDir, prefix string) ([]string, error) {
 	files, err := ioutil.ReadDir(depsDir)
 	if err != nil {

--- a/stager_test.go
+++ b/stager_test.go
@@ -610,6 +610,20 @@ var _ = Describe("Stager", func() {
 			})
 		})
 
+		Describe("BuildpackLanguage", func() {
+			It("gets buildpack language", func() {
+				Expect(s.BuildpackLanguage()).To(Equal("dotnet-core"))
+			})
+		})
+
+		Describe("BuildpackVersion", func() {
+			It("gets buildpack version", func() {
+				ver, err := s.BuildpackVersion()
+				Expect(err).To(BeNil())
+				Expect(ver).To(Equal("99.99"))
+			})
+		})
+
 		Describe("SetLaunchEnvironment", func() {
 			It("writes a .profile.d script allowing the runtime container to use the supplied deps", func() {
 				err = s.SetLaunchEnvironment()


### PR DESCRIPTION
For Hook implementations, the buildpack language and version aren't directly accessible (other than going through some files, etc.)

Having them available, it would be useful for us (Dynatrace) to ease support procedures.