### PR TITLE
Make the stack docker image configurable through ENV variable

### DIFF
--- a/cutlass/docker.go
+++ b/cutlass/docker.go
@@ -81,9 +81,15 @@ func dockerfile(fixture_path, buildpack_path string, envs []string, network_comm
 	if cfStack == "" {
 		cfStack = "cflinuxfs2"
 	}
-	out := fmt.Sprintf("FROM cloudfoundry/%s\n"+
+
+	stackDockerImage := os.Getenv("CF_STACK_DOCKER_IMAGE")
+	if stackDockerImage == "" {
+		stackDockerImage = fmt.Sprintf("cloudfoundry/%s", cfStack)
+	}
+
+	out := fmt.Sprintf("FROM %s\n"+
 		"ENV CF_STACK %s\n"+
-		"ENV VCAP_APPLICATION {}\n", cfStack, cfStack)
+		"ENV VCAP_APPLICATION {}\n", stackDockerImage, cfStack)
 	for _, env := range envs {
 		out = out + "ENV " + env + "\n"
 	}


### PR DESCRIPTION
A stack might not live under the "cloudfoundry" org or even in
dockerhub. Let the user specify CF_STACK_DOCKER_IMAGE in this case.