### PR TITLE
integration suite test helper to assert API supports sidecars

### DIFF
--- a/packager/scaffold/src/LANGUAGE/integration/_integration_suite_test.go
+++ b/packager/scaffold/src/LANGUAGE/integration/_integration_suite_test.go
@@ -100,6 +100,9 @@ func ApiHasTask() bool {
 func ApiHasMultiBuildpack() bool {
 	return ApiGreaterThan("2.90.0")
 }
+func ApiHasSidecar() bool {
+	return ApiGreaterThan("2.134.0")
+}
 
 func AssertUsesProxyDuringStagingIfPresent(fixtureName string) {
 	Context("with an uncached buildpack", func() {


### PR DESCRIPTION
Sidecars added in https://github.com/cloudfoundry/capi-release/releases/tag/1.79.0
* CC API Version: 2.134.0 and 3.69.0

Example usage:

```go
var _ = Describe("Rubyapp Integration Test", func() {
	var app *cutlass.App
	BeforeEach(func() {
		Expect(ApiHasSidecar()).To(BeTrue())
	})
```