### PR TITLE
allow arbitrary assets to be fetched from upstream

### DIFF
--- a/fixtures/manifest/fetch/manifest.yml
+++ b/fixtures/manifest/fetch/manifest.yml
@@ -117,3 +117,9 @@ dependencies:
   sha256: 8208480eb849203632239f73bd3c61ed488546d19d29c06d7c2e1649d8950bd1
   cf_stacks:
   - cflinuxfs2
+- name: wp-cli
+  version: 2.2.0
+  uri: https://github.com/wp-cli/wp-cli/releases/download/v2.2.0/wp-cli-2.2.0.phar
+  sha256: da69f286f03c0d2131b3f95afe7c8d31b4f65cbf5ca49a12c41d8bf02d366a34
+  cf_stacks:
+  - cflinuxfs2

--- a/installer.go
+++ b/installer.go
@@ -77,7 +77,12 @@ func (i *Installer) InstallDependency(dep Dependency, outputDir string) error {
 		return ExtractTarXz(tmpFile, outputDir)
 	}
 
-	return ExtractTarGz(tmpFile, outputDir)
+	if strings.HasSuffix(entry.URI, ".tar.gz") || strings.HasSuffix(entry.URI, ".tgz") {
+		return ExtractTarGz(tmpFile, outputDir)
+	}
+
+	basename := filepath.Base(entry.URI)
+	return CopyFile(tmpFile, filepath.Join(outputDir, basename))
 }
 
 func (i *Installer) warnNewerPatch(dep Dependency) error {

--- a/installer_test.go
+++ b/installer_test.go
@@ -512,6 +512,23 @@ var _ = Describe("Installer", func() {
 					Expect(ioutil.ReadFile(filepath.Join(outputDir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
 				})
 
+				Context("file does not need to be unpackaged", func() {
+					BeforeEach(func() {
+						someContents, err := ioutil.ReadFile("fixtures/source.txt")
+						Expect(err).To(BeNil())
+						httpmock.RegisterResponder("GET", "https://github.com/wp-cli/wp-cli/releases/download/v2.2.0/wp-cli-2.2.0.phar",
+							httpmock.NewStringResponder(200, string(someContents)))
+					})
+
+					It("downloads a file at the root", func() {
+						err = installer.InstallDependency(libbuildpack.Dependency{Name: "wp-cli", Version: "2.2.0"}, outputDir)
+						Expect(err).To(BeNil())
+
+						Expect(filepath.Join(outputDir, "wp-cli-2.2.0.phar")).To(BeAnExistingFile())
+						Expect(ioutil.ReadFile(filepath.Join(outputDir, "wp-cli-2.2.0.phar"))).To(Equal([]byte("a file\n")))
+					})
+				})
+
 				Context("by default, the version is NOT latest patch in version line", func() {
 					BeforeEach(func() {
 						tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")


### PR DESCRIPTION
Allow arbitrary assets to be fetched from upstream, without requiring them to be .zip/tar.xz/tar.gz

Example buildpack that uses this PR https://github.com/starkandwayne/wpcli-buildpack/blob/c32718a9c2db09ca825d024c1da10a038a6192f0/manifest.yml#L8-L14

I believe a future rewrite of the php-buildpack (when it switches from Ruby buildpack-packager to this project) will also need this PR to install `composer.phar` asset.