### PR TITLE
Add deprecated warning when "windows2016" stack is used

### DIFF
--- a/fixtures/manifest/standard/manifest.yml
+++ b/fixtures/manifest/standard/manifest.yml
@@ -132,6 +132,16 @@ dependencies:
   md5: 374ad90048055f1d11bc2ffb70ce08a7
   cf_stacks:
   - cflinuxfs2
+- name: hwc
+  version: 17.0.0
+  uri: https://buildpacks.cloudfoundry.org/dependencies/hwc/hwc-17.0.0-windows-amd64-968fe3e6.zip
+  sha256: 968fe3e663afa9da22914d48aa683553a4067480a0dd64b9d57941c89503989f
+  cf_stacks:
+  - windows2012R2
+  - windows2016
+  - windows
+  source: https://github.com/cloudfoundry/hwc/archive/17.0.0.tar.gz
+  source_sha256: b7ba44b12c99aa5f3f725360eddef1d05025f22b04be12e5a7fe149b3529b438
 exclude_files:
 - ".git/"
 - ".gitignore"

--- a/manifest.go
+++ b/manifest.go
@@ -13,9 +13,11 @@ const dateFormat = "2006-01-02"
 const thirtyDays = time.Hour * 24 * 30
 
 const (
-	CFLINUXFS2    = "cflinuxfs2"
-	ATTENTION_MSG = "!! !!"
-	WARNING_MSG   = "This application is being deployed on cflinuxfs2 which is being deprecated in April, 2019.\nPlease migrate this application to cflinuxfs3.\nFor more information about changing the stack, see https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html"
+	CFLINUXFS2              = "cflinuxfs2"
+	WINDOWS2016             = "windows2016"
+	ATTENTION_MSG           = "!! !!"
+	WARNING_MSG_CFLINUXFS2  = "This application is being deployed on cflinuxfs2 which is being deprecated in April, 2019.\nPlease migrate this application to cflinuxfs3.\nFor more information about changing the stack, see https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html"
+	WARNING_MSG_WINDOWS2016 = "This application is being deployed on the 'windows2016' stack which is deprecated.\nPlease migrate this application to the 'windows' stack (and other applications deployed on the 'windows2016' stack).\nFor more information about changing the stack, see https://docs.cloudfoundry.org/devguide/deploy-apps/windows-stacks.html"
 )
 
 type Dependency struct {
@@ -191,7 +193,11 @@ func (m *Manifest) CheckStackSupport() error {
 	requiredStack := os.Getenv("CF_STACK")
 
 	if requiredStack == CFLINUXFS2 {
-		m.log.Warning("\n" + ATTENTION_MSG + "\n" + WARNING_MSG + "\n" + ATTENTION_MSG)
+		m.log.Warning("\n" + ATTENTION_MSG + "\n" + WARNING_MSG_CFLINUXFS2 + "\n" + ATTENTION_MSG)
+	}
+
+	if requiredStack == WINDOWS2016 {
+		m.log.Warning("\n" + ATTENTION_MSG + "\n" + WARNING_MSG_WINDOWS2016 + "\n" + ATTENTION_MSG)
 	}
 
 	if m.manifestSupportsStack(requiredStack) {

--- a/manifest.go
+++ b/manifest.go
@@ -17,7 +17,7 @@ const (
 	WINDOWS2016             = "windows2016"
 	ATTENTION_MSG           = "!! !!"
 	WARNING_MSG_CFLINUXFS2  = "This application is being deployed on cflinuxfs2 which is being deprecated in April, 2019.\nPlease migrate this application to cflinuxfs3.\nFor more information about changing the stack, see https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html"
-	WARNING_MSG_WINDOWS2016 = "This application is being deployed on the 'windows2016' stack which is deprecated.\nPlease migrate this application to the 'windows' stack (and other applications deployed on the 'windows2016' stack).\nFor more information about changing the stack, see https://docs.cloudfoundry.org/devguide/deploy-apps/windows-stacks.html"
+	WARNING_MSG_WINDOWS2016 = "This application is being deployed on the 'windows2016' stack which is deprecated.\nPlease restage this application to the 'windows' stack with '-s windows'.\nAny other applications deployed to the 'windows2016' stack should also be restaged to '-s windows'.\nFor more information, see https://docs.cloudfoundry.org/devguide/deploy-apps/windows-stacks.html"
 )
 
 type Dependency struct {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -166,6 +166,15 @@ ruby:
 			})
 		})
 
+		Context("stack is windows2016", func() {
+			It("prints a warning message", func() {
+				err = os.Setenv("CF_STACK", libbuildpack.WINDOWS2016)
+				Expect(err).To(BeNil())
+				Expect(manifest.CheckStackSupport()).To(Succeed())
+				Expect(buffer.String()).To(ContainSubstring("Please migrate this application to the 'windows' stack"))
+			})
+		})
+
 		Context("Stack is not supported", func() {
 			Context("stacks specified in dependencies", func() {
 				BeforeEach(func() {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -171,7 +171,7 @@ ruby:
 				err = os.Setenv("CF_STACK", libbuildpack.WINDOWS2016)
 				Expect(err).To(BeNil())
 				Expect(manifest.CheckStackSupport()).To(Succeed())
-				Expect(buffer.String()).To(ContainSubstring("Please migrate this application to the 'windows' stack"))
+				Expect(buffer.String()).To(ContainSubstring("Please restage this application to the 'windows' stack"))
 			})
 		})
 


### PR DESCRIPTION
The stack "windows2016" is deprecated in favor of the "windows"
stack. Users should get a deprecated warning when they try to
cf-push an app with "-s windows2016".

There's no change change in the stack except for the name.

[#167028439](https://www.pivotaltracker.com/story/show/167028439)

Signed-off-by: Arjun Sreedharan <asreedharan@pivotal.io>
