### PR TITLE
scaffold/install_go: temporarily use fs3 go for fs4

### DIFF
--- a/packager/scaffold/scripts/install_go.sh
+++ b/packager/scaffold/scripts/install_go.sh
@@ -4,8 +4,11 @@ set -euo pipefail
 
 GO_VERSION="1.13.5"
 
-if [ $CF_STACK == "cflinuxfs3" ]; then
+if [ $CF_STACK == "cflinuxfs3" || $CF_STACK == "cflinuxfs4" ]; then
     GO_SHA256="fedef14df0fc373546067501db2009d31516bfe9217045028b4cf8fd06afc9df"
+    # TODO remove this when we have a go buildpack on cflinuxfs4
+    # cflinuxfs3 go dependency should work fine on cflinuxfs4 until then
+    CF_STACK="cflinuxfs4"
 else
   echo "       **ERROR** Unsupported stack"
   echo "                 See https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html for more info"


### PR DESCRIPTION
We are building the dotnet-core-buildpack to be the first
buildpack to run on cflinuxfs4. Until go dependencies are ready
for cflinuxfs4, use the cflinuxfs3 based go dependency.

This code is run when unbuilt buildpacks are directly used.
E.g.
```
cf push app -b https://github.com/cloudfoundry/dotnet-core-buildpack#develop -s cflinuxfs4
```

Also see
https://buildpacks.ci.cf-app.com/teams/main/pipelines/dotnet-core-buildpack/jobs/specs-edge-brats-develop/builds/1070#L62d62271:207