### PR TITLE
dockerfile: only move tcpdump if not exist

### DIFF
--- a/cutlass/docker/dockerfile.go
+++ b/cutlass/docker/dockerfile.go
@@ -34,7 +34,7 @@ func BuildStagingDockerfile(logger lager.Logger, fixturePath, buildpackPath stri
 		instructions = append(instructions, NewDockerfileENV(env))
 	}
 	// HACK around https://github.com/dotcloud/docker/issues/5490
-	instructions = append(instructions, NewDockerfileRUN("mv /usr/sbin/tcpdump /usr/bin/tcpdump"))
+	instructions = append(instructions, NewDockerfileRUN("if [ ! -f /usr/bin/tcpdump ]; then mv /usr/sbin/tcpdump /usr/bin/tcpdump; fi"))
 
 	instructions = append(instructions, NewDockerfileRUN("chmod o+rwx /tmp"))
 	instructions = append(instructions, NewDockerfileRUN("chown vcap /tmp/ -R"))

--- a/cutlass/docker/dockerfile_test.go
+++ b/cutlass/docker/dockerfile_test.go
@@ -28,7 +28,7 @@ ENV CF_STACK cflinuxfs3
 ENV VCAP_APPLICATION {}
 ENV some-env
 ENV other-env
-RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
+RUN if [ ! -f /usr/bin/tcpdump ]; then mv /usr/sbin/tcpdump /usr/bin/tcpdump; fi
 RUN chmod o+rwx /tmp
 RUN chown vcap /tmp/ -R
 RUN mkdir /vcap-home
@@ -58,7 +58,7 @@ ENV CF_STACK some-stack
 ENV VCAP_APPLICATION {}
 ENV some-env
 ENV other-env
-RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
+RUN if [ ! -f /usr/bin/tcpdump ]; then mv /usr/sbin/tcpdump /usr/bin/tcpdump; fi
 RUN chmod o+rwx /tmp
 RUN chown vcap /tmp/ -R
 RUN mkdir /vcap-home
@@ -90,7 +90,7 @@ ENV CF_STACK cflinuxfs3
 ENV VCAP_APPLICATION {}
 ENV some-env
 ENV other-env
-RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
+RUN if [ ! -f /usr/bin/tcpdump ]; then mv /usr/sbin/tcpdump /usr/bin/tcpdump; fi
 RUN chmod o+rwx /tmp
 RUN chown vcap /tmp/ -R
 RUN mkdir /vcap-home


### PR DESCRIPTION
cflinuxfs4 already has /usr/bin/tcpdump