### PR TITLE
Remove low value tests.

### DIFF
--- a/bratshelper/tests.go
+++ b/bratshelper/tests.go
@@ -1,15 +1,10 @@
 package bratshelper
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/cloudfoundry/libbuildpack"
@@ -56,142 +51,6 @@ func UnbuiltBuildpack(depName string, copyBrats func(string) *cutlass.App) {
 	})
 }
 
-func DeployingAnAppWithAnUpdatedVersionOfTheSameBuildpack(copyBrats func(string) *cutlass.App) {
-	Describe("deploying an app with an updated version of the same buildpack", func() {
-		var (
-			bpName, stack string
-			app           *cutlass.App
-		)
-		BeforeEach(func() {
-			bpName = GenBpName("changing")
-			app = copyBrats("")
-			app.Buildpacks = []string{bpName + "_buildpack"}
-			stackAssociationSupported, err := cutlass.ApiGreaterThan("2.113.0")
-			Expect(err).ToNot(HaveOccurred())
-			if stackAssociationSupported {
-				stack = app.Stack
-			} else {
-				stack = ""
-			}
-		})
-		AfterEach(func() {
-			defaultCleanup(app)
-			Expect(cutlass.DeleteBuildpack(bpName)).To(Succeed())
-			// With stacks, creating the buildpack twice will result in a second record, one with `nil` stack.
-			// We need to clean up both.
-			if count, err := cutlass.CountBuildpack(bpName, ""); err == nil && count > 0 {
-				Expect(cutlass.DeleteBuildpack(bpName)).To(Succeed(), "Attempted to delete buildpack %s", bpName)
-			}
-			// LTS errors when running `cf buildpacks`. Ignore that output.
-			count, err := cutlass.CountBuildpack(bpName, "")
-			if err == nil {
-				Expect(count).To(BeZero(), "There are %d %s buildpacks", count, bpName)
-			}
-		})
-
-		It("prints useful warning message to stdout", func() {
-			Expect(cutlass.CreateOrUpdateBuildpack(bpName, Data.UncachedFile, stack)).To(Succeed())
-			PushApp(app)
-			Expect(app.Stdout.String()).ToNot(ContainSubstring("buildpack version changed from"))
-
-			newFile, err := ModifyBuildpack(Data.UncachedFile, func(path string, r io.Reader) (io.Reader, error) {
-				if path == "VERSION" {
-					return strings.NewReader("NewVersion"), nil
-				}
-				return r, nil
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cutlass.CreateOrUpdateBuildpack(bpName, newFile, stack)).To(Succeed(), "Could not create or update %s on %s", bpName, stack)
-			PushApp(app)
-			Expect(app.Stdout.String()).To(MatchRegexp(`buildpack version changed from (\S+) to NewVersion`))
-		})
-	})
-}
-
-func StagingWithBuildpackThatSetsEOL(depName string, copyBrats func(string) *cutlass.App) {
-	Describe("staging with "+depName+" buildpack that sets EOL on dependency", func() {
-		var (
-			eolDate, buildpackFile, bpName, stack string
-			app                                   *cutlass.App
-		)
-		JustBeforeEach(func() {
-			eolDate = time.Now().AddDate(0, 0, 10).Format("2006-01-02")
-			file, err := ModifyBuildpackManifest(buildpackFile, func(m *Manifest) {
-				for _, eol := range m.DependencyDeprecationDates {
-					if eol.Name == depName {
-						eol.Date = eolDate
-					}
-				}
-			})
-			Expect(err).ToNot(HaveOccurred())
-			bpName = GenBpName("eol")
-			app = copyBrats("")
-			app.Buildpacks = []string{bpName + "_buildpack"}
-			stackAssociationSupported, err := cutlass.ApiGreaterThan("2.113.0")
-			Expect(err).ToNot(HaveOccurred())
-			if stackAssociationSupported {
-				stack = app.Stack
-			} else {
-				stack = ""
-			}
-
-			Expect(cutlass.CreateOrUpdateBuildpack(bpName, file, stack)).To(Succeed())
-			os.Remove(file)
-
-			PushApp(app)
-		})
-		AfterEach(func() {
-			defaultCleanup(app)
-			Expect(cutlass.DeleteBuildpack(bpName)).To(Succeed())
-		})
-
-		Context("using an uncached buildpack", func() {
-			BeforeEach(func() {
-				buildpackFile = Data.UncachedFile
-			})
-			It("warns about end of life", func() {
-				Expect(app.Stdout.String()).To(MatchRegexp(`WARNING.*` + depName + ` \S+ will no longer be available in new buildpacks released after`))
-			})
-		})
-
-		Context("using a cached buildpack", func() {
-			BeforeEach(func() {
-				buildpackFile = Data.CachedFile
-			})
-			It("warns about end of life", func() {
-				Expect(app.Stdout.String()).To(MatchRegexp(`WARNING.*` + depName + ` \S+ will no longer be available in new buildpacks released after`))
-			})
-		})
-	})
-}
-
-func StagingWithADepThatIsNotTheLatestConstrained(depName string, versionConstraint string, copyBrats func(string) *cutlass.App) {
-	Describe("staging with a version of "+depName+" that is not the latest patch release in the manifest", func() {
-		var app *cutlass.App
-		BeforeEach(func() {
-			manifest, err := libbuildpack.NewManifest(Data.BpDir, nil, time.Now())
-			Expect(err).ToNot(HaveOccurred(), "Making new manifest from %s: error is %v", Data.BpDir, err)
-			versions, err := libbuildpack.FindMatchingVersions(versionConstraint, manifest.AllDependencyVersions(depName))
-			Expect(err).ToNot(HaveOccurred(), "Finding matching version: error is %v", err)
-			app = copyBrats(versions[0])
-			app.Buildpacks = []string{Data.Cached}
-			PushApp(app)
-		})
-		AfterEach(func() {
-			defaultCleanup(app)
-		})
-
-		It("logs a warning that tells the user to upgrade the dependency", func() {
-			Expect(app.Stdout.String()).To(MatchRegexp("WARNING.*A newer version of " + depName + " is available in this buildpack"))
-		})
-	})
-}
-
-func StagingWithADepThatIsNotTheLatest(depName string, copyBrats func(string) *cutlass.App) {
-	StagingWithADepThatIsNotTheLatestConstrained(depName, "x", copyBrats)
-}
-
 func DeployAppWithExecutableProfileScript(depName string, copyBrats func(string) *cutlass.App) {
 	Describe("deploying an app that has an executable .profile script", func() {
 		var app *cutlass.App
@@ -221,45 +80,6 @@ func DeployAppWithExecutableProfileScript(depName string, copyBrats func(string)
 			_, headers, err := app.Get("/.profile", map[string]string{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(headers).To(HaveKeyWithValue("StatusCode", []string{"404"}))
-		})
-	})
-}
-
-func DeployAnAppWithSensitiveEnvironmentVariables(copyBrats func(string) *cutlass.App) {
-	Describe("deploying an app that has sensitive environment variables", func() {
-		var app *cutlass.App
-		BeforeEach(func() {
-			app = copyBrats("")
-			app.Buildpacks = []string{Data.Cached}
-			app.SetEnv("MY_SPECIAL_VAR", "SUPER SENSITIVE DATA")
-			PushApp(app)
-		})
-		AfterEach(func() {
-			defaultCleanup(app)
-		})
-
-		It("will not write credentials to the app droplet", func() {
-			Expect(app.DownloadDroplet(filepath.Join(app.Path, "droplet.tgz"))).To(Succeed())
-			file, err := os.Open(filepath.Join(app.Path, "droplet.tgz"))
-			Expect(err).ToNot(HaveOccurred())
-			defer file.Close()
-			gz, err := gzip.NewReader(file)
-			Expect(err).ToNot(HaveOccurred())
-			defer gz.Close()
-			tr := tar.NewReader(gz)
-
-			for {
-				hdr, err := tr.Next()
-				if err == io.EOF {
-					break
-				}
-				b, err := ioutil.ReadAll(tr)
-				for _, content := range []string{"MY_SPECIAL_VAR", "SUPER SENSITIVE DATA"} {
-					if strings.Contains(string(b), content) {
-						Fail(fmt.Sprintf("Found sensitive string %s in %s", content, hdr.Name))
-					}
-				}
-			}
 		})
 	})
 }


### PR DESCRIPTION
## Summary

This PR removes the brats test listed below. I have two goals with this:

1. Removing tests that I think are low value. Typically this is tests that are slow/expensive (i.e. integration tests) that could be tested at the unit test level, as well as tests that I think are philosophically pointless (like negative tests) and therefore add cognitive load to a developer regardless of how quickly or slowly they run.
1. Making BRATS fast enough to tack on to the end of an existing integration/specs run rather than requiring a whole separate environment. The cost of this is fairly minimal - adding 5-20 mins onto the end of the existing integration test job - but the savings are significant, as it means not waiting for a shepherd pool env (and not encountering flakiness assigning/releasing it). As a data point, typically each brats tests takes 2-3 minutes, so this PR will save about 10-15 minutes (in the worst case, as not all buildpacks run all brats tests) over just inlining the brats as-is.

### List of tests removed, with justification

- `DeployingAnAppWithAnUpdatedVersionOfTheSameBuildpack`: We cover this with a unit test. I do not think we also need an integration test
- `StagingWithBuildpackThatSetsEOL`: Not all dependencies have deprecation dates, and we have unit tests to cover this when dependencies do have deprecation dates.
- `StagingWithADepThatIsNotTheLatestConstrained/StagingWithADepThatIsNotTheLatest`: I do not think this provides much value to customers, and we have unit tests to cover this.
- `DeployAnAppWithSensitiveEnvironmentVariables`: I think these sorts of tests are unhelpful. There are an infinite number of negative test cases we can run - validating that the buildpack does perform a specific action is best tested at the unit level (if at all).

### Future work

I think we could get to the point where we don't need to run brats at all, because we can inline the remaining tests into the integration test for each buildpack:

* There is one actual test remaining (the `.profile` test) which should be fairly easily to port into each buildpack's integration test suite and thus remove from brats.
* The remaining test harness - run for all dependency versions - could be turned into some helper functions and the testing itself moved into each buildpack's integration test suite, again, allowing for its removal from brats.