### PR TITLE
fix: replace deprecated io/ioutil and rand.Seed with modern Go equivalents

### DIFF
--- a/bratshelper/data.go
+++ b/bratshelper/data.go
@@ -3,7 +3,6 @@ package bratshelper
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +35,7 @@ func InitBpData(stack string, stackAssociationSupported bool) *BpData {
 	Data.BpDir, err = cutlass.FindRoot()
 	Expect(err).NotTo(HaveOccurred())
 
-	file, err := ioutil.ReadFile(filepath.Join(Data.BpDir, "manifest.yml"))
+	file, err := os.ReadFile(filepath.Join(Data.BpDir, "manifest.yml"))
 	Expect(err).ToNot(HaveOccurred())
 	obj := make(map[string]interface{})
 	Expect(yaml.Unmarshal(file, &obj)).To(Succeed())

--- a/bratshelper/language.go
+++ b/bratshelper/language.go
@@ -1,7 +1,7 @@
 package bratshelper
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/cloudfoundry/libbuildpack/cutlass"
@@ -13,7 +13,7 @@ var cachedLanguage string
 
 func bpLanguage() string {
 	if cachedLanguage == "" {
-		file, err := ioutil.ReadFile(filepath.Join(bpDir(), "manifest.yml"))
+		file, err := os.ReadFile(filepath.Join(bpDir(), "manifest.yml"))
 		Expect(err).ToNot(HaveOccurred())
 		obj := make(map[string]interface{})
 		Expect(yaml.Unmarshal(file, &obj)).To(Succeed())

--- a/bratshelper/modify.go
+++ b/bratshelper/modify.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 
 	yaml "gopkg.in/yaml.v2"
@@ -70,7 +69,7 @@ func modifyZipfile(path string, cb func(path string, r io.Reader) (io.Reader, er
 	}
 	defer r.Close()
 
-	newfile, err := ioutil.TempFile("", "buildpack.zip")
+	newfile, err := os.CreateTemp("", "buildpack.zip")
 	if err != nil {
 		return "", err
 	}
@@ -117,7 +116,7 @@ func modifyZipfile(path string, cb func(path string, r io.Reader) (io.Reader, er
 }
 
 func changeManifest(r io.Reader, cb func(*Manifest)) (io.Reader, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/bratshelper/utils.go
+++ b/bratshelper/utils.go
@@ -1,7 +1,7 @@
 package bratshelper
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -22,7 +22,7 @@ func DestroyApp(app *cutlass.App) {
 
 func AddDotProfileScriptToApp(dir string) {
 	profilePath := filepath.Join(dir, ".profile")
-	Expect(ioutil.WriteFile(profilePath, []byte(`#!/usr/bin/env bash
+	Expect(os.WriteFile(profilePath, []byte(`#!/usr/bin/env bash
 echo PROFILE_SCRIPT_IS_PRESENT_AND_RAN
 `), 0755)).To(Succeed())
 }

--- a/checksum/checksum_test.go
+++ b/checksum/checksum_test.go
@@ -3,7 +3,6 @@ package checksum_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -23,13 +22,13 @@ var _ = Describe("Checksum", func() {
 
 	BeforeEach(func() {
 		var err error
-		dir, err = ioutil.TempDir("", "checksum")
+		dir, err = os.MkdirTemp("", "checksum")
 		Expect(err).To(BeNil())
 		DeferCleanup(os.RemoveAll, dir)
 
 		Expect(os.MkdirAll(filepath.Join(dir, ".cloudfoundry"), 0755)).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(dir, "a", "b"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(dir, "a/b", "file"), []byte("hi"), 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(dir, "a/b", "file"), []byte("hi"), 0644)).To(Succeed())
 
 		lines = []string{}
 		exec = func() error { return nil }
@@ -54,7 +53,7 @@ var _ = Describe("Checksum", func() {
 			BeforeEach(func() {
 				exec = func() error {
 					time.Sleep(10 * time.Millisecond)
-					return ioutil.WriteFile(filepath.Join(dir, "a/b", "file"), []byte("bye"), 0644)
+					return os.WriteFile(filepath.Join(dir, "a/b", "file"), []byte("bye"), 0644)
 				}
 			})
 
@@ -73,7 +72,7 @@ var _ = Describe("Checksum", func() {
 			BeforeEach(func() {
 				exec = func() error {
 					time.Sleep(10 * time.Millisecond)
-					return ioutil.WriteFile(filepath.Join(dir, "a", "file"), []byte("new file"), 0644)
+					return os.WriteFile(filepath.Join(dir, "a", "file"), []byte("new file"), 0644)
 				}
 			})
 
@@ -93,7 +92,7 @@ var _ = Describe("Checksum", func() {
 			BeforeEach(func() {
 				exec = func() error {
 					time.Sleep(10 * time.Millisecond)
-					return ioutil.WriteFile(filepath.Join(dir, ".cloudfoundry", "file"), []byte("bye"), 0644)
+					return os.WriteFile(filepath.Join(dir, ".cloudfoundry", "file"), []byte("bye"), 0644)
 				}
 			})
 

--- a/cutlass/cf.go
+++ b/cutlass/cf.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -254,7 +254,7 @@ func (a *App) SpaceGUID() (string, error) {
 	if cfHome == "" {
 		cfHome = os.Getenv("HOME")
 	}
-	bytes, err := ioutil.ReadFile(filepath.Join(cfHome, ".cf", "config.json"))
+	bytes, err := os.ReadFile(filepath.Join(cfHome, ".cf", "config.json"))
 	if err != nil {
 		return "", err
 	}
@@ -466,7 +466,7 @@ func (a *App) Get(path string, headers map[string]string) (string, map[string][]
 		return "", map[string][]string{}, err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", map[string][]string{}, err
 	}

--- a/cutlass/docker.go
+++ b/cutlass/docker.go
@@ -3,7 +3,6 @@ package cutlass
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -51,7 +50,7 @@ func InternetTrafficForNetwork(networkName, fixturePath, buildpackPath string, e
 	session := DefaultLogger.Session("internet-traffic-for-network", data)
 
 	session.Debug("preparing-docker-build-context")
-	tmpDir, err := ioutil.TempDir("", "docker-context")
+	tmpDir, err := os.MkdirTemp("", "docker-context")
 	if err != nil {
 		return nil, false, nil, fmt.Errorf("failed to create docker context directory: %s", err)
 	}

--- a/cutlass/glow/archiver.go
+++ b/cutlass/glow/archiver.go
@@ -2,7 +2,7 @@ package glow
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 )
@@ -25,7 +25,7 @@ func NewArchiver(packager Packager) Archiver {
 }
 
 func (a Archiver) Archive(dir, stack, tag string, cached bool) (string, error) {
-	version, err := ioutil.ReadFile(filepath.Join(dir, "VERSION"))
+	version, err := os.ReadFile(filepath.Join(dir, "VERSION"))
 	if err != nil {
 		return "", err
 	}

--- a/cutlass/glow/archiver_test.go
+++ b/cutlass/glow/archiver_test.go
@@ -2,7 +2,6 @@ package glow_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -23,7 +22,7 @@ var _ = Describe("Archiver", func() {
 
 	BeforeEach(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "archiver")
+		tmpDir, err = os.MkdirTemp("", "archiver")
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(os.RemoveAll, tmpDir)
 
@@ -35,7 +34,7 @@ var _ = Describe("Archiver", func() {
 
 	Describe("Archive", func() {
 		BeforeEach(func() {
-			err := ioutil.WriteFile(filepath.Join(tmpDir, "VERSION"), []byte("1.2.3"), 0644)
+			err := os.WriteFile(filepath.Join(tmpDir, "VERSION"), []byte("1.2.3"), 0644)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/cutlass/proxy.go
+++ b/cutlass/proxy.go
@@ -2,10 +2,10 @@ package cutlass
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http/httptest"
 	"net/url"
+	"os"
 
 	"github.com/elazarl/goproxy"
 )
@@ -34,7 +34,7 @@ func main() {
 	proxyURL, err := url.Parse(p.URL)
 	listenMsg := fmt.Sprintf("Listening on Port: %s", proxyURL.Port())
 	fmt.Println(listenMsg)
-	if err := ioutil.WriteFile("server.log", []byte(listenMsg), 0644); err != nil {
+	if err := os.WriteFile("server.log", []byte(listenMsg), 0644); err != nil {
 		fmt.Println("Failed to write to log")
 	}
 

--- a/cutlass/test_helpers.go
+++ b/cutlass/test_helpers.go
@@ -5,9 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -111,7 +109,7 @@ func PackageUniquelyVersionedBuildpack(stack string, stackAssociationSupported b
 		return VersionedBuildpackPackage{}, fmt.Errorf("Failed to find root: %v", err)
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join(bpDir, "VERSION"))
+	data, err := os.ReadFile(filepath.Join(bpDir, "VERSION"))
 	if err != nil {
 		return VersionedBuildpackPackage{}, fmt.Errorf("Failed to read VERSION file: %v", err)
 	}
@@ -220,7 +218,7 @@ func CopyCfHome() error {
 	if cf_home == "" {
 		cf_home = os.Getenv("HOME")
 	}
-	cf_home_new, err := ioutil.TempDir("", "cf-home-copy")
+	cf_home_new, err := os.MkdirTemp("", "cf-home-copy")
 	if err != nil {
 		return err
 	}
@@ -235,8 +233,6 @@ func CopyCfHome() error {
 }
 
 func SeedRandom() {
-	seed := int64(time.Now().Nanosecond() + os.Getpid())
-	rand.Seed(seed)
 }
 
 func RemovePackagedBuildpack(buildpack VersionedBuildpackPackage) error {
@@ -265,7 +261,7 @@ func readVersionFromZip(filePath string) (string, error) {
 			return "", err
 		}
 
-		out, err := ioutil.ReadAll(rc)
+		out, err := io.ReadAll(rc)
 		if err != nil {
 			return "", err
 

--- a/cutlass/utils.go
+++ b/cutlass/utils.go
@@ -2,7 +2,6 @@ package cutlass
 
 import (
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -12,7 +11,7 @@ import (
 )
 
 func CopyFixture(srcDir string) (string, error) {
-	destDir, err := ioutil.TempDir("", "cutlass-fixture-copy")
+	destDir, err := os.MkdirTemp("", "cutlass-fixture-copy")
 	if err != nil {
 		return "", err
 	}

--- a/cutlass/v7/cf.go
+++ b/cutlass/v7/cf.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -268,7 +268,7 @@ func (a *App) SpaceGUID() (string, error) {
 	if cfHome == "" {
 		cfHome = os.Getenv("HOME")
 	}
-	bytes, err := ioutil.ReadFile(filepath.Join(cfHome, ".cf", "config.json"))
+	bytes, err := os.ReadFile(filepath.Join(cfHome, ".cf", "config.json"))
 	if err != nil {
 		return "", err
 	}
@@ -447,7 +447,7 @@ func (a *App) Get(path string, headers map[string]string) (string, map[string][]
 		return "", map[string][]string{}, err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", map[string][]string{}, err
 	}

--- a/cutlass/v7/test_helpers.go
+++ b/cutlass/v7/test_helpers.go
@@ -5,9 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,7 +111,7 @@ func PackageUniquelyVersionedBuildpack(stack string, stackAssociationSupported b
 		return VersionedBuildpackPackage{}, fmt.Errorf("Failed to find root: %v", err)
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join(bpDir, "VERSION"))
+	data, err := os.ReadFile(filepath.Join(bpDir, "VERSION"))
 	if err != nil {
 		return VersionedBuildpackPackage{}, fmt.Errorf("Failed to read VERSION file: %v", err)
 	}
@@ -222,7 +220,7 @@ func CopyCfHome() error {
 	if cf_home == "" {
 		cf_home = os.Getenv("HOME")
 	}
-	cf_home_new, err := ioutil.TempDir("", "cf-home-copy")
+	cf_home_new, err := os.MkdirTemp("", "cf-home-copy")
 	if err != nil {
 		return err
 	}
@@ -237,8 +235,6 @@ func CopyCfHome() error {
 }
 
 func SeedRandom() {
-	seed := int64(time.Now().Nanosecond() + os.Getpid())
-	rand.Seed(seed)
 }
 
 func RemovePackagedBuildpack(buildpack VersionedBuildpackPackage) error {
@@ -267,7 +263,7 @@ func readVersionFromZip(filePath string) (string, error) {
 			return "", err
 		}
 
-		out, err := ioutil.ReadAll(rc)
+		out, err := io.ReadAll(rc)
 		if err != nil {
 			return "", err
 

--- a/installer.go
+++ b/installer.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,7 +46,7 @@ func (i *Installer) InstallDependency(dep Dependency, outputDir string) error {
 func (i *Installer) InstallDependencyWithStrip(dep Dependency, outputDir string, stripComponents int) error {
 	i.manifest.log.BeginStep("Installing %s %s", dep.Name, dep.Version)
 
-	tmpDir, err := ioutil.TempDir("", "downloads")
+	tmpDir, err := os.MkdirTemp("", "downloads")
 	if err != nil {
 		return err
 	}

--- a/installer_test.go
+++ b/installer_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -65,14 +64,14 @@ var _ = Describe("Installer", func() {
 		)
 
 		BeforeEach(func() {
-			tmpdir, err = ioutil.TempDir("", "downloads")
+			tmpdir, err = os.MkdirTemp("", "downloads")
 			Expect(err).To(BeNil())
 			DeferCleanup(os.RemoveAll, tmpdir)
 			outputFile = filepath.Join(tmpdir, "out.tgz")
 
-			manifestDir, err = ioutil.TempDir("", "buildpack")
+			manifestDir, err = os.MkdirTemp("", "buildpack")
 			Expect(err).To(BeNil())
-			appCacheDir, err = ioutil.TempDir("", "appCache")
+			appCacheDir, err = os.MkdirTemp("", "appCache")
 			Expect(err).To(BeNil())
 			DeferCleanup(os.RemoveAll, appCacheDir)
 
@@ -115,27 +114,27 @@ var _ = Describe("Installer", func() {
 			Context("dependency exists cached on disk and matches checksum", func() {
 				BeforeEach(func() {
 					os.MkdirAll(filepath.Dir(inputs.pathToCachedFile), 0755)
-					Expect(ioutil.WriteFile(inputs.pathToCachedFile, inputs.expectedContents, 0644)).To(Succeed())
+					Expect(os.WriteFile(inputs.pathToCachedFile, inputs.expectedContents, 0644)).To(Succeed())
 				})
 				It("copies the cached file to outputFile", func() {
 					err = installer.FetchDependency(inputs.dependency, outputFile)
 
 					Expect(err).To(BeNil())
-					Expect(ioutil.ReadFile(outputFile)).To(Equal(inputs.expectedContents))
+					Expect(os.ReadFile(outputFile)).To(Equal(inputs.expectedContents))
 				})
 				It("makes intermediate directories", func() {
 					outputFile = filepath.Join(tmpdir, "notexist", "out.tgz")
 					err = installer.FetchDependency(inputs.dependency, outputFile)
 
 					Expect(err).To(BeNil())
-					Expect(ioutil.ReadFile(outputFile)).To(Equal(inputs.expectedContents))
+					Expect(os.ReadFile(outputFile)).To(Equal(inputs.expectedContents))
 				})
 			})
 
 			Context("dependency exists cached on disk and does not match checksum", func() {
 				BeforeEach(func() {
 					os.MkdirAll(filepath.Dir(inputs.pathToCachedFile), 0755)
-					Expect(ioutil.WriteFile(inputs.pathToCachedFile, append(inputs.expectedContents, []byte(" except not")...), 0644)).To(Succeed())
+					Expect(os.WriteFile(inputs.pathToCachedFile, append(inputs.expectedContents, []byte(" except not")...), 0644)).To(Succeed())
 				})
 				It("raises error", func() {
 					err = installer.FetchDependency(inputs.dependency, outputFile)
@@ -178,7 +177,7 @@ var _ = Describe("Installer", func() {
 					err = installer.FetchDependency(inputs.Dependency, outputFile)
 
 					Expect(err).To(BeNil())
-					Expect(ioutil.ReadFile(outputFile)).To(Equal(inputs.ExpectedContent))
+					Expect(os.ReadFile(outputFile)).To(Equal(inputs.ExpectedContent))
 				})
 				inputs.CheckOnSuccess()
 
@@ -187,7 +186,7 @@ var _ = Describe("Installer", func() {
 					err = installer.FetchDependency(inputs.Dependency, outputFile)
 
 					Expect(err).To(BeNil())
-					Expect(ioutil.ReadFile(outputFile)).To(Equal(inputs.ExpectedContent))
+					Expect(os.ReadFile(outputFile)).To(Equal(inputs.ExpectedContent))
 				})
 			})
 			Context("url returns error then success and matches checksum", func() {
@@ -205,7 +204,7 @@ var _ = Describe("Installer", func() {
 					err = installer.FetchDependency(inputs.Dependency, outputFile)
 
 					Expect(err).To(BeNil())
-					Expect(ioutil.ReadFile(outputFile)).To(Equal(inputs.ExpectedContent))
+					Expect(os.ReadFile(outputFile)).To(Equal(inputs.ExpectedContent))
 				})
 				inputs.CheckOnSuccess()
 
@@ -214,7 +213,7 @@ var _ = Describe("Installer", func() {
 					err = installer.FetchDependency(inputs.Dependency, outputFile)
 
 					Expect(err).To(BeNil())
-					Expect(ioutil.ReadFile(outputFile)).To(Equal(inputs.ExpectedContent))
+					Expect(os.ReadFile(outputFile)).To(Equal(inputs.ExpectedContent))
 				})
 
 				It("retries to get success", func() {
@@ -337,7 +336,7 @@ var _ = Describe("Installer", func() {
 					It("downloads the file to the cache location", func() {
 						Expect(installer.FetchDependency(entryToFetch.entry.Dependency, outputFile)).To(Succeed())
 
-						Expect(ioutil.ReadFile(entryToFetch.appCachePath)).To(Equal(entryToFetch.content))
+						Expect(os.ReadFile(entryToFetch.appCachePath)).To(Equal(entryToFetch.content))
 					})
 				}
 				checkOnError := func() {
@@ -364,19 +363,19 @@ var _ = Describe("Installer", func() {
 					// create file in app cache dir
 					extraFile := filepath.Join(appCacheDir, "dependencies", "abcdef0123456789", "decoyFile")
 					Expect(os.MkdirAll(filepath.Dir(extraFile), 0755)).To(Succeed())
-					Expect(ioutil.WriteFile(extraFile, []byte("decoy content"), 0644)).To(Succeed())
+					Expect(os.WriteFile(extraFile, []byte("decoy content"), 0644)).To(Succeed())
 					extraFilePaths = append(extraFilePaths, extraFile)
 
 					// create file for real dependency in manifest
 					extraOtherDepFile := filepath.Join(appCacheDir, "dependencies", "662eacac1df6ae7eee9ccd1ac1eb1d0d8777c403e5375fd64d14907f875f50c0", "some-dependency-name-5.tgz")
 					os.MkdirAll(filepath.Dir(extraOtherDepFile), 0755)
-					Expect(ioutil.WriteFile(extraOtherDepFile, []byte("some super legit dependency content"), 0644)).To(Succeed())
+					Expect(os.WriteFile(extraOtherDepFile, []byte("some super legit dependency content"), 0644)).To(Succeed())
 					extraFilePaths = append(extraFilePaths, extraOtherDepFile)
 
 					// create extra file for the fetched dependency
 					extraDepFile := filepath.Join(filepath.Dir(entryToFetch.appCachePath), "decoyDep.zip")
 					os.MkdirAll(filepath.Dir(extraDepFile), 0755)
-					Expect(ioutil.WriteFile(extraDepFile, []byte("some more decoy content"), 0644)).To(Succeed())
+					Expect(os.WriteFile(extraDepFile, []byte("some more decoy content"), 0644)).To(Succeed())
 					extraFilePaths = append(extraFilePaths, extraDepFile)
 
 					// Add extra dependency to manifest & rewrite that file
@@ -401,7 +400,7 @@ var _ = Describe("Installer", func() {
 					It("downloads the file to the cache location", func() {
 						Expect(installer.FetchDependency(entryToFetch.entry.Dependency, outputFile)).To(Succeed())
 
-						Expect(ioutil.ReadFile(entryToFetch.appCachePath)).To(Equal(entryToFetch.content))
+						Expect(os.ReadFile(entryToFetch.appCachePath)).To(Equal(entryToFetch.content))
 					})
 					It("everything else is deleted", func() {
 						Expect(installer.FetchDependency(entryToFetch.entry.Dependency, outputFile)).To(Succeed())
@@ -474,7 +473,7 @@ var _ = Describe("Installer", func() {
 		)
 
 		BeforeEach(func() {
-			appCacheDir, err = ioutil.TempDir("", "appCache")
+			appCacheDir, err = os.MkdirTemp("", "appCache")
 			Expect(err).To(BeNil())
 		})
 		JustBeforeEach(func() {
@@ -494,7 +493,7 @@ var _ = Describe("Installer", func() {
 			BeforeEach(func() {
 				Expect(os.Mkdir(filepath.Join(appCacheDir, "dependencies"), 0755)).To(Succeed())
 				Expect(os.Mkdir(filepath.Join(appCacheDir, "dependencies", "abcd"), 0755)).To(Succeed())
-				Expect(ioutil.WriteFile(filepath.Join(appCacheDir, "dependencies", "abcd", "file.tgz"), []byte("contents"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(appCacheDir, "dependencies", "abcd", "file.tgz"), []byte("contents"), 0644)).To(Succeed())
 			})
 			It("deletes old files", func() {
 				Expect(filepath.Join(appCacheDir, "dependencies", "abcd", "file.tgz")).To(BeARegularFile())
@@ -510,7 +509,7 @@ var _ = Describe("Installer", func() {
 		var outputDir string
 
 		BeforeEach(func() {
-			outputDir, err = ioutil.TempDir("", "downloads")
+			outputDir, err = os.MkdirTemp("", "downloads")
 			Expect(err).To(BeNil())
 			DeferCleanup(os.RemoveAll, outputDir)
 		})
@@ -521,7 +520,7 @@ var _ = Describe("Installer", func() {
 			})
 			Context("url exists and matches sha256", func() {
 				BeforeEach(func() {
-					tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")
+					tgzContents, err := os.ReadFile("fixtures/thing.tgz")
 					Expect(err).To(BeNil())
 					httpmock.RegisterResponder("GET", "https://example.com/dependencies/real_tar_file-3-linux-x64.tgz",
 						httpmock.NewStringResponder(200, string(tgzContents)))
@@ -539,7 +538,7 @@ var _ = Describe("Installer", func() {
 					Expect(err).To(BeNil())
 
 					Expect(filepath.Join(outputDir, "root.txt")).To(BeAnExistingFile())
-					Expect(ioutil.ReadFile(filepath.Join(outputDir, "root.txt"))).To(Equal([]byte("root\n")))
+					Expect(os.ReadFile(filepath.Join(outputDir, "root.txt"))).To(Equal([]byte("root\n")))
 				})
 
 				It("extracts a nested file", func() {
@@ -547,7 +546,7 @@ var _ = Describe("Installer", func() {
 					Expect(err).To(BeNil())
 
 					Expect(filepath.Join(outputDir, "thing", "bin", "file2.exe")).To(BeAnExistingFile())
-					Expect(ioutil.ReadFile(filepath.Join(outputDir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
+					Expect(os.ReadFile(filepath.Join(outputDir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
 				})
 
 				It("makes intermediate directories", func() {
@@ -556,12 +555,12 @@ var _ = Describe("Installer", func() {
 					Expect(err).To(BeNil())
 
 					Expect(filepath.Join(outputDir, "thing", "bin", "file2.exe")).To(BeAnExistingFile())
-					Expect(ioutil.ReadFile(filepath.Join(outputDir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
+					Expect(os.ReadFile(filepath.Join(outputDir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
 				})
 
 				Context("file does not need to be unpackaged", func() {
 					BeforeEach(func() {
-						someContents, err := ioutil.ReadFile("fixtures/source.txt")
+						someContents, err := os.ReadFile("fixtures/source.txt")
 						Expect(err).To(BeNil())
 						httpmock.RegisterResponder("GET", "https://github.com/wp-cli/wp-cli/releases/download/v2.2.0/wp-cli-2.2.0.phar",
 							httpmock.NewStringResponder(200, string(someContents)))
@@ -572,13 +571,13 @@ var _ = Describe("Installer", func() {
 						Expect(err).To(BeNil())
 
 						Expect(filepath.Join(outputDir, "wp-cli-2.2.0.phar")).To(BeAnExistingFile())
-						Expect(ioutil.ReadFile(filepath.Join(outputDir, "wp-cli-2.2.0.phar"))).To(Equal([]byte("a file\n")))
+						Expect(os.ReadFile(filepath.Join(outputDir, "wp-cli-2.2.0.phar"))).To(Equal([]byte("a file\n")))
 					})
 				})
 
 				Context("by default, the version is NOT latest patch in version line", func() {
 					BeforeEach(func() {
-						tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")
+						tgzContents, err := os.ReadFile("fixtures/thing.tgz")
 						Expect(err).To(BeNil())
 						httpmock.RegisterResponder("GET", "https://example.com/dependencies/thing-6.2.2-linux-x64.tgz",
 							httpmock.NewStringResponder(200, string(tgzContents)))
@@ -597,7 +596,7 @@ var _ = Describe("Installer", func() {
 
 				Context("when there is a greater minor version and a greater patch version", func() {
 					BeforeEach(func() {
-						tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")
+						tgzContents, err := os.ReadFile("fixtures/thing.tgz")
 						Expect(err).To(BeNil())
 						httpmock.RegisterResponder("GET", "https://example.com/dependencies/thing-8.1.2-linux-x64.tgz",
 							httpmock.NewStringResponder(200, string(tgzContents)))
@@ -617,7 +616,7 @@ var _ = Describe("Installer", func() {
 
 				Context("when the version line in a manifest is by patch line and the version installed is not the latest patch in that line", func() {
 					BeforeEach(func() {
-						tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")
+						tgzContents, err := os.ReadFile("fixtures/thing.tgz")
 						Expect(err).To(BeNil())
 						httpmock.RegisterResponder("GET", "https://example.com/dependencies/thing-8.1.2-linux-x64.tgz",
 							httpmock.NewStringResponder(200, string(tgzContents)))
@@ -637,7 +636,7 @@ var _ = Describe("Installer", func() {
 
 				Context("version is latest in version line", func() {
 					BeforeEach(func() {
-						tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")
+						tgzContents, err := os.ReadFile("fixtures/thing.tgz")
 						Expect(err).To(BeNil())
 						httpmock.RegisterResponder("GET", "https://example.com/dependencies/thing-6.2.3-linux-x64.tgz",
 							httpmock.NewStringResponder(200, string(tgzContents)))
@@ -652,7 +651,7 @@ var _ = Describe("Installer", func() {
 
 				Context("version is not semver", func() {
 					BeforeEach(func() {
-						tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")
+						tgzContents, err := os.ReadFile("fixtures/thing.tgz")
 						Expect(err).To(BeNil())
 						httpmock.RegisterResponder("GET", "https://buildpacks.cloudfoundry.org/dependencies/godep/godep-v79-linux-x64-9e37ce0f.tgz",
 							httpmock.NewStringResponder(200, string(tgzContents)))
@@ -668,7 +667,7 @@ var _ = Describe("Installer", func() {
 				Context("version has an EOL, version line is major", func() {
 					const warning = "**WARNING** thing 4.x will no longer be available in new buildpacks released after 2017-03-01."
 					BeforeEach(func() {
-						tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")
+						tgzContents, err := os.ReadFile("fixtures/thing.tgz")
 						Expect(err).To(BeNil())
 						httpmock.RegisterResponder("GET", "https://example.com/dependencies/thing-4.6.1-linux-x64.tgz",
 							httpmock.NewStringResponder(200, string(tgzContents)))
@@ -696,7 +695,7 @@ var _ = Describe("Installer", func() {
 
 						Context("dependency EOL does not have a link associated with it", func() {
 							BeforeEach(func() {
-								tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")
+								tgzContents, err := os.ReadFile("fixtures/thing.tgz")
 								Expect(err).To(BeNil())
 								httpmock.RegisterResponder("GET", "https://example.com/dependencies/thing-5.2.3-linux-x64.tgz",
 									httpmock.NewStringResponder(200, string(tgzContents)))
@@ -736,7 +735,7 @@ var _ = Describe("Installer", func() {
 				Context("version has an EOL, version line is major + minor", func() {
 					const warning = "**WARNING** thing 6.2.x will no longer be available in new buildpacks released after 2018-04-01"
 					BeforeEach(func() {
-						tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")
+						tgzContents, err := os.ReadFile("fixtures/thing.tgz")
 						Expect(err).To(BeNil())
 						httpmock.RegisterResponder("GET", "https://example.com/dependencies/thing-6.2.3-linux-x64.tgz",
 							httpmock.NewStringResponder(200, string(tgzContents)))
@@ -780,7 +779,7 @@ var _ = Describe("Installer", func() {
 				Context("version has an EOL, version line non semver", func() {
 					const warning = "**WARNING** nonsemver abc-1.2.3-def-4.5.6 will no longer be available in new buildpacks released after 2018-04-01"
 					BeforeEach(func() {
-						tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")
+						tgzContents, err := os.ReadFile("fixtures/thing.tgz")
 						Expect(err).To(BeNil())
 						httpmock.RegisterResponder("GET", "https://example.com/dependencies/nonsemver-abc-1.2.3-def-4.5.6-linux-x64.tgz",
 							httpmock.NewStringResponder(200, string(tgzContents)))
@@ -824,7 +823,7 @@ var _ = Describe("Installer", func() {
 				Context("version does not have an EOL", func() {
 					const warning = "**WARNING** real_tar_file 3 will no longer be available in new buildpacks released after"
 					BeforeEach(func() {
-						tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")
+						tgzContents, err := os.ReadFile("fixtures/thing.tgz")
 						Expect(err).To(BeNil())
 						httpmock.RegisterResponder("GET", "https://example.com/dependencies/real_tar_file-3-linux-x64.tgz",
 							httpmock.NewStringResponder(200, string(tgzContents)))
@@ -867,19 +866,19 @@ var _ = Describe("Installer", func() {
 			)
 
 			BeforeEach(func() {
-				manifestDir, err = ioutil.TempDir("", "cached")
+				manifestDir, err = os.MkdirTemp("", "cached")
 				Expect(err).To(BeNil())
 
 				dependenciesDir = filepath.Join(manifestDir, "dependencies")
 				os.MkdirAll(dependenciesDir, 0755)
 
-				data, err := ioutil.ReadFile("fixtures/manifest/fetch_cached/manifest.yml")
+				data, err := os.ReadFile("fixtures/manifest/fetch_cached/manifest.yml")
 				Expect(err).To(BeNil())
 
-				err = ioutil.WriteFile(filepath.Join(manifestDir, "manifest.yml"), data, 0644)
+				err = os.WriteFile(filepath.Join(manifestDir, "manifest.yml"), data, 0644)
 				Expect(err).To(BeNil())
 
-				outputDir, err = ioutil.TempDir("", "downloads")
+				outputDir, err = os.MkdirTemp("", "downloads")
 				Expect(err).To(BeNil())
 			})
 
@@ -900,7 +899,7 @@ var _ = Describe("Installer", func() {
 					Expect(err).To(BeNil())
 
 					Expect(filepath.Join(outputDir, "root.txt")).To(BeAnExistingFile())
-					Expect(ioutil.ReadFile(filepath.Join(outputDir, "root.txt"))).To(Equal([]byte("root\n")))
+					Expect(os.ReadFile(filepath.Join(outputDir, "root.txt"))).To(Equal([]byte("root\n")))
 				})
 
 				It("extracts a nested file", func() {
@@ -908,7 +907,7 @@ var _ = Describe("Installer", func() {
 					Expect(err).To(BeNil())
 
 					Expect(filepath.Join(outputDir, "thing", "bin", "file2.exe")).To(BeAnExistingFile())
-					Expect(ioutil.ReadFile(filepath.Join(outputDir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
+					Expect(os.ReadFile(filepath.Join(outputDir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
 				})
 
 				It("makes intermediate directories", func() {
@@ -917,7 +916,7 @@ var _ = Describe("Installer", func() {
 					Expect(err).To(BeNil())
 
 					Expect(filepath.Join(outputDir, "thing", "bin", "file2.exe")).To(BeAnExistingFile())
-					Expect(ioutil.ReadFile(filepath.Join(outputDir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
+					Expect(os.ReadFile(filepath.Join(outputDir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
 				})
 			})
 		})
@@ -928,14 +927,14 @@ var _ = Describe("Installer", func() {
 
 		BeforeEach(func() {
 			manifestDir = "fixtures/manifest/fetch"
-			outputDir, err = ioutil.TempDir("", "downloads")
+			outputDir, err = os.MkdirTemp("", "downloads")
 			Expect(err).To(BeNil())
 			DeferCleanup(os.RemoveAll, outputDir)
 		})
 
 		Context("there is only one version of the dependency", func() {
 			BeforeEach(func() {
-				tgzContents, err := ioutil.ReadFile("fixtures/thing.tgz")
+				tgzContents, err := os.ReadFile("fixtures/thing.tgz")
 				Expect(err).To(BeNil())
 				httpmock.RegisterResponder("GET", "https://example.com/dependencies/real_tar_file-3-linux-x64.tgz",
 					httpmock.NewStringResponder(200, string(tgzContents)))
@@ -947,7 +946,7 @@ var _ = Describe("Installer", func() {
 				Expect(err).To(BeNil())
 
 				Expect(filepath.Join(outputDir, "thing", "bin", "file2.exe")).To(BeAnExistingFile())
-				Expect(ioutil.ReadFile(filepath.Join(outputDir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
+				Expect(os.ReadFile(filepath.Join(outputDir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
 			})
 		})
 

--- a/json.go
+++ b/json.go
@@ -3,7 +3,7 @@ package libbuildpack
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 type JSON struct {
@@ -30,7 +30,7 @@ func removeBOM(b []byte) []byte {
 }
 
 func (j *JSON) Load(file string, obj interface{}) error {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/json_test.go
+++ b/json_test.go
@@ -1,7 +1,6 @@
 package libbuildpack_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -18,7 +17,7 @@ var _ = Describe("JSON", func() {
 	)
 
 	BeforeEach(func() {
-		tmpDir, err = ioutil.TempDir("", "json")
+		tmpDir, err = os.MkdirTemp("", "json")
 		Expect(err).To(BeNil())
 		DeferCleanup(os.RemoveAll, tmpDir)
 
@@ -29,7 +28,7 @@ var _ = Describe("JSON", func() {
 		Context("file is valid json", func() {
 			Context("that starts with BOM", func() {
 				BeforeEach(func() {
-					ioutil.WriteFile(filepath.Join(tmpDir, "valid.json"), []byte("\uFEFF"+`{"key": "value"}`), 0666)
+					os.WriteFile(filepath.Join(tmpDir, "valid.json"), []byte("\uFEFF"+`{"key": "value"}`), 0666)
 				})
 				It("returns an error", func() {
 					obj := make(map[string]string)
@@ -41,7 +40,7 @@ var _ = Describe("JSON", func() {
 			})
 			Context("that does not start with BOM", func() {
 				BeforeEach(func() {
-					ioutil.WriteFile(filepath.Join(tmpDir, "valid.json"), []byte(`{"key": "value"}`), 0666)
+					os.WriteFile(filepath.Join(tmpDir, "valid.json"), []byte(`{"key": "value"}`), 0666)
 				})
 				It("returns an error", func() {
 					obj := make(map[string]string)
@@ -55,7 +54,7 @@ var _ = Describe("JSON", func() {
 
 		Context("file is NOT valid json", func() {
 			BeforeEach(func() {
-				ioutil.WriteFile(filepath.Join(tmpDir, "invalid.json"), []byte("not valid json"), 0666)
+				os.WriteFile(filepath.Join(tmpDir, "invalid.json"), []byte("not valid json"), 0666)
 			})
 			It("returns an error", func() {
 				obj := make(map[string]string)
@@ -82,7 +81,7 @@ var _ = Describe("JSON", func() {
 				err = json.Write(filepath.Join(tmpDir, "file.json"), obj)
 				Expect(err).To(BeNil())
 
-				Expect(ioutil.ReadFile(filepath.Join(tmpDir, "file.json"))).To(Equal([]byte(`{"key":"val"}`)))
+				Expect(os.ReadFile(filepath.Join(tmpDir, "file.json"))).To(Equal([]byte(`{"key":"val"}`)))
 			})
 		})
 
@@ -94,7 +93,7 @@ var _ = Describe("JSON", func() {
 				err = json.Write(filepath.Join(tmpDir, "extradir", "file.json"), obj)
 				Expect(err).To(BeNil())
 
-				Expect(ioutil.ReadFile(filepath.Join(tmpDir, "extradir", "file.json"))).To(Equal([]byte(`{"key":"val"}`)))
+				Expect(os.ReadFile(filepath.Join(tmpDir, "extradir", "file.json"))).To(Equal([]byte(`{"key":"val"}`)))
 			})
 		})
 	})

--- a/manifest.go
+++ b/manifest.go
@@ -2,7 +2,6 @@ package libbuildpack
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -179,7 +178,7 @@ func (m *Manifest) Language() string {
 }
 
 func (m *Manifest) Version() (string, error) {
-	version, err := ioutil.ReadFile(filepath.Join(m.manifestRootDir, "VERSION"))
+	version, err := os.ReadFile(filepath.Join(m.manifestRootDir, "VERSION"))
 	if err != nil {
 		return "", fmt.Errorf("unable to read VERSION file %s", err)
 	}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -3,7 +3,6 @@ package libbuildpack_test
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -53,7 +52,7 @@ var _ = Describe("Manifest", func() {
 	Describe("ApplyOverride", func() {
 		var depsDir string
 		BeforeEach(func() {
-			depsDir, err = ioutil.TempDir("", "libbuildpack_override")
+			depsDir, err = os.MkdirTemp("", "libbuildpack_override")
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(os.RemoveAll, depsDir)
 			Expect(os.Mkdir(filepath.Join(depsDir, "0"), 0755)).To(Succeed())
@@ -83,7 +82,7 @@ ruby:
     version: 2.2.2
     cf_stacks: ['cflinuxfs2']
 `
-			Expect(ioutil.WriteFile(filepath.Join(depsDir, "1", "override.yml"), []byte(data), 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(depsDir, "1", "override.yml"), []byte(data), 0644)).To(Succeed())
 		})
 
 		It("updates default version", func() {
@@ -291,14 +290,14 @@ ruby:
 	Describe("IsCached", func() {
 		BeforeEach(func() {
 			var err error
-			manifestDir, err = ioutil.TempDir("", "cached")
+			manifestDir, err = os.MkdirTemp("", "cached")
 			Expect(err).To(BeNil())
 			DeferCleanup(os.RemoveAll, manifestDir)
 
-			data, err := ioutil.ReadFile("fixtures/manifest/fetch/manifest.yml")
+			data, err := os.ReadFile("fixtures/manifest/fetch/manifest.yml")
 			Expect(err).To(BeNil())
 
-			err = ioutil.WriteFile(filepath.Join(manifestDir, "manifest.yml"), data, 0644)
+			err = os.WriteFile(filepath.Join(manifestDir, "manifest.yml"), data, 0644)
 			Expect(err).To(BeNil())
 		})
 		Context("uncached buildpack", func() {
@@ -394,7 +393,7 @@ ruby:
 		var cacheDir string
 
 		BeforeEach(func() {
-			cacheDir, err = ioutil.TempDir("", "cache")
+			cacheDir, err = os.MkdirTemp("", "cache")
 			DeferCleanup(os.RemoveAll, cacheDir)
 		})
 
@@ -402,7 +401,7 @@ ruby:
 			Context("The language does not match", func() {
 				BeforeEach(func() {
 					metadata := "---\nlanguage: diffLang\nversion: 99.99"
-					ioutil.WriteFile(filepath.Join(cacheDir, "BUILDPACK_METADATA"), []byte(metadata), 0666)
+					os.WriteFile(filepath.Join(cacheDir, "BUILDPACK_METADATA"), []byte(metadata), 0666)
 				})
 
 				It("Does not log anything", func() {
@@ -414,7 +413,7 @@ ruby:
 				Context("The version matches", func() {
 					BeforeEach(func() {
 						metadata := "---\nlanguage: dotnet-core\nversion: 99.99"
-						ioutil.WriteFile(filepath.Join(cacheDir, "BUILDPACK_METADATA"), []byte(metadata), 0666)
+						os.WriteFile(filepath.Join(cacheDir, "BUILDPACK_METADATA"), []byte(metadata), 0666)
 					})
 
 					It("Does not log anything", func() {
@@ -427,7 +426,7 @@ ruby:
 				Context("The version does not match", func() {
 					BeforeEach(func() {
 						metadata := "---\nlanguage: dotnet-core\nversion: 33.99"
-						ioutil.WriteFile(filepath.Join(cacheDir, "BUILDPACK_METADATA"), []byte(metadata), 0666)
+						os.WriteFile(filepath.Join(cacheDir, "BUILDPACK_METADATA"), []byte(metadata), 0666)
 					})
 
 					It("Logs a warning that the buildpack version has changed", func() {
@@ -452,7 +451,7 @@ ruby:
 		var cacheDir string
 
 		BeforeEach(func() {
-			cacheDir, err = ioutil.TempDir("", "cache")
+			cacheDir, err = os.MkdirTemp("", "cache")
 			DeferCleanup(os.RemoveAll, cacheDir)
 		})
 

--- a/packager/bindata.go
+++ b/packager/bindata.go
@@ -41,7 +41,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -995,7 +994,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/packager/buildpack-packager/main.go
+++ b/packager/buildpack-packager/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -69,7 +68,7 @@ func (b *buildCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{})
 		return subcommands.ExitFailure
 	}
 	if b.version == "" {
-		v, err := ioutil.ReadFile("VERSION")
+		v, err := os.ReadFile("VERSION")
 		if err != nil {
 			log.Printf("error: Could not read VERSION file: %v", err)
 			return subcommands.ExitFailure

--- a/packager/cfbindata.go
+++ b/packager/cfbindata.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,7 +56,7 @@ func OurRestoreAsset(dir, name string, funcMap template.FuncMap, shas map[string
 	}
 
 	oldSha256 := ""
-	if oldContents, err := ioutil.ReadFile(_filePath(dir, name)); err == nil {
+	if oldContents, err := os.ReadFile(_filePath(dir, name)); err == nil {
 		oldSha256 = checksumHex(oldContents)
 	}
 
@@ -72,7 +71,7 @@ func OurRestoreAsset(dir, name string, funcMap template.FuncMap, shas map[string
 		return err
 	}
 
-	if err := ioutil.WriteFile(_filePath(dir, name), b.Bytes(), info.Mode()); err != nil {
+	if err := os.WriteFile(_filePath(dir, name), b.Bytes(), info.Mode()); err != nil {
 		return err
 	}
 

--- a/packager/packager.go
+++ b/packager/packager.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -27,7 +26,7 @@ type sha struct {
 }
 
 func readManifest(bpDir string) (Manifest, error) {
-	data, err := ioutil.ReadFile(filepath.Join(bpDir, "manifest.yml"))
+	data, err := os.ReadFile(filepath.Join(bpDir, "manifest.yml"))
 	if err != nil {
 		return Manifest{}, err
 	}
@@ -53,7 +52,7 @@ func CompileExtensionPackage(bpDir, version string, cached bool, stack string) (
 		return "", fmt.Errorf("Failed to copy %s: %v", bpDir, err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(dir, "VERSION"), []byte(version), 0644)
+	err = os.WriteFile(filepath.Join(dir, "VERSION"), []byte(version), 0644)
 	if err != nil {
 		return "", fmt.Errorf("Failed to write VERSION file: %v", err)
 	}
@@ -168,7 +167,7 @@ func Package(bpDir, cacheDir, version, stack string, cached bool) (string, error
 	}
 	defer os.RemoveAll(dir)
 
-	err = ioutil.WriteFile(filepath.Join(dir, "VERSION"), []byte(version), 0644)
+	err = os.WriteFile(filepath.Join(dir, "VERSION"), []byte(version), 0644)
 	if err != nil {
 		return "", err
 	}
@@ -304,7 +303,7 @@ func DownloadFromURI(uri, fileName string) error {
 }
 
 func checkSha256(filePath, expectedSha256 string) error {
-	content, err := ioutil.ReadFile(filePath)
+	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return err
 	}
@@ -373,7 +372,7 @@ func ZipFiles(filename string, files []File) error {
 }
 
 func CopyDirectory(srcDir string) (string, error) {
-	destDir, err := ioutil.TempDir("", "buildpack-packager")
+	destDir, err := os.MkdirTemp("", "buildpack-packager")
 	if err != nil {
 		return "", err
 	}

--- a/packager/packager_suite_test.go
+++ b/packager/packager_suite_test.go
@@ -3,7 +3,7 @@ package packager_test
 import (
 	"archive/zip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"testing"
 
@@ -37,7 +37,7 @@ func ZipContents(zipFile, file string) (string, error) {
 				return "", err
 			}
 			defer rc.Close()
-			body, err := ioutil.ReadAll(rc)
+			body, err := io.ReadAll(rc)
 			if err != nil {
 				return "", err
 			}

--- a/packager/packager_test.go
+++ b/packager/packager_test.go
@@ -3,7 +3,6 @@ package packager_test
 import (
 	"crypto/md5"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -32,7 +31,7 @@ var _ = Describe("Packager", func() {
 	BeforeEach(func() {
 		stack = "cflinuxfs2"
 		buildpackDir = "./fixtures/good"
-		cacheDir, err = ioutil.TempDir("", "packager-cachedir")
+		cacheDir, err = os.MkdirTemp("", "packager-cachedir")
 		Expect(err).To(BeNil())
 		version = fmt.Sprintf("1.23.45.%s", time.Now().Format("20060102150405"))
 
@@ -47,7 +46,7 @@ var _ = Describe("Packager", func() {
 
 		BeforeEach(func() {
 			var err error
-			destDir, err = ioutil.TempDir("", "packager-download")
+			destDir, err = os.MkdirTemp("", "packager-download")
 			Expect(err).To(BeNil())
 			DeferCleanup(os.RemoveAll, destDir)
 			destFile = filepath.Join(destDir, "some_dep_1.2.3+4_linux.tgz")
@@ -257,22 +256,22 @@ var _ = Describe("Packager", func() {
 				var tempfile string
 				BeforeEach(func() {
 					var err error
-					tempdir, err := ioutil.TempDir("", "bp_fixture")
+					tempdir, err := os.MkdirTemp("", "bp_fixture")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(libbuildpack.CopyDirectory(buildpackDir, tempdir)).To(Succeed())
 
-					fh, err := ioutil.TempFile("", "bp_dependency")
+					fh, err := os.CreateTemp("", "bp_dependency")
 					Expect(err).ToNot(HaveOccurred())
 					fh.WriteString("keaty")
 					fh.Close()
 					tempfile = fh.Name()
 
-					manifestyml, err := ioutil.ReadFile(filepath.Join(tempdir, "manifest.yml"))
+					manifestyml, err := os.ReadFile(filepath.Join(tempdir, "manifest.yml"))
 					Expect(err).ToNot(HaveOccurred())
 					manifestyml2 := string(manifestyml)
 					manifestyml2 = strings.Replace(manifestyml2, "https://www.ietf.org/rfc/rfc2324.txt", "file://"+tempfile, -1)
 					manifestyml2 = strings.Replace(manifestyml2, "b11329c3fd6dbe9dddcb8dd90f18a4bf441858a6b5bfaccae5f91e5c7d2b3596", "f909ee4c4bec3280bbbff6b41529479366ab10c602d8aed33e3a86f0a9c5db4e", -1)
-					Expect(ioutil.WriteFile(filepath.Join(tempdir, "manifest.yml"), []byte(manifestyml2), 0644)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(tempdir, "manifest.yml"), []byte(manifestyml2), 0644)).To(Succeed())
 
 					buildpackDir = tempdir
 					DeferCleanup(os.RemoveAll, buildpackDir)

--- a/packager/summary.go
+++ b/packager/summary.go
@@ -2,7 +2,7 @@ package packager
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -12,7 +12,7 @@ import (
 
 func Summary(bpDir string) (string, error) {
 	manifest := Manifest{}
-	data, err := ioutil.ReadFile(filepath.Join(bpDir, "manifest.yml"))
+	data, err := os.ReadFile(filepath.Join(bpDir, "manifest.yml"))
 	if err != nil {
 		return "", err
 	}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -4,7 +4,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,7 +38,7 @@ func Dir(dir string, logger Logger) *DirSnapshot {
 			dirSnapshot.initialChecksum = checksum
 		}
 
-		dirSnapshot.command.Execute(dir, ioutil.Discard, ioutil.Discard, "touch", "/tmp/checkpoint")
+		dirSnapshot.command.Execute(dir, io.Discard, io.Discard, "touch", "/tmp/checkpoint")
 	}
 
 	return dirSnapshot

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -1,7 +1,6 @@
 package snapshot_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -28,14 +27,14 @@ var _ = Describe("Snapshot", func() {
 		origBPDebug = os.Getenv("BP_DEBUG")
 		DeferCleanup(os.Setenv, "BP_DEBUG", origBPDebug)
 
-		tmpDir, err = ioutil.TempDir("", "libbuildpack.snapshot.build.")
+		tmpDir, err = os.MkdirTemp("", "libbuildpack.snapshot.build.")
 		Expect(err).To(BeNil())
 		DeferCleanup(os.RemoveAll, tmpDir)
 
-		Expect(ioutil.WriteFile(filepath.Join(tmpDir, "Gemfile"), []byte("source \"https://rubygems.org\"\r\ngem \"rack\"\r\n"), 0644)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(tmpDir, "other"), []byte("other"), 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(tmpDir, "Gemfile"), []byte("source \"https://rubygems.org\"\r\ngem \"rack\"\r\n"), 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(tmpDir, "other"), []byte("other"), 0644)).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(tmpDir, "dir"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(tmpDir, "dir", "other"), []byte("other"), 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(tmpDir, "dir", "other"), []byte("other"), 0644)).To(Succeed())
 		Expect(os.Symlink(filepath.Join(tmpDir, "Gemfile"), filepath.Join(tmpDir, "mySymLink"))).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(tmpDir, "myEmptyDir"), 0755)).To(Succeed())
 
@@ -56,8 +55,8 @@ var _ = Describe("Snapshot", func() {
 		Context(".cloudfoundry directory", func() {
 			BeforeEach(func() {
 				Expect(os.MkdirAll(filepath.Join(tmpDir, ".cloudfoundry", "dir"), 0755)).To(Succeed())
-				Expect(ioutil.WriteFile(filepath.Join(tmpDir, ".cloudfoundry", "other"), []byte("other"), 0644)).To(Succeed())
-				Expect(ioutil.WriteFile(filepath.Join(tmpDir, ".cloudfoundry", "dir", "other"), []byte("other"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(tmpDir, ".cloudfoundry", "other"), []byte("other"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(tmpDir, ".cloudfoundry", "dir", "other"), []byte("other"), 0644)).To(Succeed())
 			})
 
 			It("excludes .cloudfoundry directory in the checksum calcuation", func() {
@@ -142,7 +141,7 @@ var _ = Describe("Snapshot", func() {
 
 			Context("when a file is added", func() {
 				BeforeEach(func() {
-					Expect(ioutil.WriteFile(filepath.Join(tmpDir, "extrafile"), []byte("extrafile"), 0644)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(tmpDir, "extrafile"), []byte("extrafile"), 0644)).To(Succeed())
 				})
 
 				It("logs the new MD5 sum as well as changed paths", func() {
@@ -168,7 +167,7 @@ var _ = Describe("Snapshot", func() {
 
 			Context("when a files contents have changed", func() {
 				BeforeEach(func() {
-					Expect(ioutil.WriteFile(filepath.Join(tmpDir, "other"), []byte("other other"), 0644)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(tmpDir, "other"), []byte("other other"), 0644)).To(Succeed())
 				})
 
 				It("logs the new MD5 sum as well as changed paths", func() {
@@ -201,7 +200,7 @@ var _ = Describe("Snapshot", func() {
 			var dirSnapshot *snapshot.DirSnapshot
 			BeforeEach(func() {
 				dirSnapshot = snapshot.Dir(tmpDir, mockLogger)
-				Expect(ioutil.WriteFile(filepath.Join(tmpDir, "other"), []byte("other other"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(tmpDir, "other"), []byte("other other"), 0644)).To(Succeed())
 			})
 			It("Does not log anything", func() {
 				dirSnapshot.Diff()

--- a/stager.go
+++ b/stager.go
@@ -3,7 +3,6 @@ package libbuildpack
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -95,7 +94,7 @@ func (s *Stager) WriteEnvFile(envVar, envVal string) error {
 
 	}
 
-	return ioutil.WriteFile(filepath.Join(envDir, envVar), []byte(envVal), 0644)
+	return os.WriteFile(filepath.Join(envDir, envVar), []byte(envVal), 0644)
 }
 
 func (s *Stager) LinkDirectoryInDepDir(destDir, depSubDir string) error {
@@ -104,7 +103,7 @@ func (s *Stager) LinkDirectoryInDepDir(destDir, depSubDir string) error {
 		return err
 	}
 
-	files, err := ioutil.ReadDir(destDir)
+	files, err := os.ReadDir(destDir)
 	if err != nil {
 		return err
 	}
@@ -153,7 +152,7 @@ func (s *Stager) StagingComplete() {
 }
 
 func (s *Stager) ClearCache() error {
-	files, err := ioutil.ReadDir(s.cacheDir)
+	files, err := os.ReadDir(s.cacheDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -172,7 +171,7 @@ func (s *Stager) ClearCache() error {
 }
 
 func (s *Stager) ClearDepDir() error {
-	files, err := ioutil.ReadDir(s.DepDir())
+	files, err := os.ReadDir(s.DepDir())
 	if err != nil {
 		return err
 	}
@@ -234,14 +233,14 @@ func (s *Stager) SetStagingEnvironment() error {
 	}
 
 	for _, dir := range depsPaths {
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		if err != nil {
 			return err
 		}
 
 		for _, file := range files {
-			if file.Mode().IsRegular() {
-				val, err := ioutil.ReadFile(filepath.Join(dir, file.Name()))
+			if file.Type().IsRegular() {
+				val, err := os.ReadFile(filepath.Join(dir, file.Name()))
 				if err != nil {
 					return err
 				}
@@ -293,13 +292,13 @@ func (s *Stager) SetLaunchEnvironment() error {
 
 		depsIdx := sections[len(sections)-2]
 
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		if err != nil {
 			return err
 		}
 
 		for _, file := range files {
-			if file.Mode().IsRegular() {
+			if file.Type().IsRegular() {
 				src := filepath.Join(dir, file.Name())
 				dest := filepath.Join(s.profileDir, depsIdx+"_"+file.Name())
 
@@ -322,7 +321,7 @@ func (s *Stager) BuildpackVersion() (string, error) {
 }
 
 func existingDepsDirs(depsDir, subDir, prefix string) ([]string, error) {
-	files, err := ioutil.ReadDir(depsDir)
+	files, err := os.ReadDir(depsDir)
 	if err != nil {
 		return nil, err
 	}

--- a/stager_test.go
+++ b/stager_test.go
@@ -3,7 +3,6 @@ package libbuildpack_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -31,15 +30,15 @@ var _ = Describe("Stager", func() {
 	)
 
 	BeforeEach(func() {
-		buildDir, err = ioutil.TempDir("", "build")
+		buildDir, err = os.MkdirTemp("", "build")
 		Expect(err).To(BeNil())
 		DeferCleanup(os.RemoveAll, buildDir)
 
-		cacheDir, err = ioutil.TempDir("", "cache")
+		cacheDir, err = os.MkdirTemp("", "cache")
 		Expect(err).To(BeNil())
 		DeferCleanup(os.RemoveAll, cacheDir)
 
-		depsDir, err = ioutil.TempDir("", "deps")
+		depsDir, err = os.MkdirTemp("", "deps")
 		Expect(err).To(BeNil())
 		DeferCleanup(os.RemoveAll, depsDir)
 
@@ -47,7 +46,7 @@ var _ = Describe("Stager", func() {
 		err = os.MkdirAll(filepath.Join(depsDir, depsIdx), 0755)
 		Expect(err).To(BeNil())
 
-		profileDir, err = ioutil.TempDir("", "profiled")
+		profileDir, err = os.MkdirTemp("", "profiled")
 		Expect(err).To(BeNil())
 		DeferCleanup(os.RemoveAll, profileDir)
 
@@ -179,10 +178,10 @@ var _ = Describe("Stager", func() {
 		Context("not empty", func() {
 			BeforeEach(func() {
 				Expect(os.MkdirAll(filepath.Join(cacheDir, "fred", "jane"), 0755)).To(Succeed())
-				Expect(ioutil.WriteFile(filepath.Join(cacheDir, "fred", "jane", "jack.txt"), []byte("content"), 0644)).To(Succeed())
-				Expect(ioutil.WriteFile(filepath.Join(cacheDir, "jill.txt"), []byte("content"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(cacheDir, "fred", "jane", "jack.txt"), []byte("content"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(cacheDir, "jill.txt"), []byte("content"), 0644)).To(Succeed())
 
-				fi, err := ioutil.ReadDir(cacheDir)
+				fi, err := os.ReadDir(cacheDir)
 				Expect(err).To(BeNil())
 				Expect(len(fi)).To(Equal(2))
 			})
@@ -192,7 +191,7 @@ var _ = Describe("Stager", func() {
 				Expect(err).To(BeNil())
 				Expect(cacheDir).To(BeADirectory())
 
-				fi, err := ioutil.ReadDir(cacheDir)
+				fi, err := os.ReadDir(cacheDir)
 				Expect(err).To(BeNil())
 				Expect(len(fi)).To(Equal(0))
 			})
@@ -211,11 +210,11 @@ var _ = Describe("Stager", func() {
 		Context("not empty", func() {
 			BeforeEach(func() {
 				Expect(os.MkdirAll(filepath.Join(depsDir, depsIdx, "fred", "jane"), 0755)).To(Succeed())
-				Expect(ioutil.WriteFile(filepath.Join(depsDir, depsIdx, "fred", "jane", "jack.txt"), []byte("content"), 0644)).To(Succeed())
-				Expect(ioutil.WriteFile(filepath.Join(depsDir, depsIdx, "jill.txt"), []byte("content"), 0644)).To(Succeed())
-				Expect(ioutil.WriteFile(filepath.Join(depsDir, depsIdx, "config.yml"), []byte("yaml"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(depsDir, depsIdx, "fred", "jane", "jack.txt"), []byte("content"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(depsDir, depsIdx, "jill.txt"), []byte("content"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(depsDir, depsIdx, "config.yml"), []byte("yaml"), 0644)).To(Succeed())
 
-				fi, err := ioutil.ReadDir(filepath.Join(depsDir, depsIdx))
+				fi, err := os.ReadDir(filepath.Join(depsDir, depsIdx))
 				Expect(err).To(BeNil())
 				Expect(len(fi)).To(Equal(3))
 			})
@@ -225,11 +224,11 @@ var _ = Describe("Stager", func() {
 				Expect(err).To(BeNil())
 				Expect(s.DepDir()).To(BeADirectory())
 
-				fi, err := ioutil.ReadDir(s.DepDir())
+				fi, err := os.ReadDir(s.DepDir())
 				Expect(err).To(BeNil())
 				Expect(len(fi)).To(Equal(1))
 
-				content, err := ioutil.ReadFile(filepath.Join(s.DepDir(), "config.yml"))
+				content, err := os.ReadFile(filepath.Join(s.DepDir(), "config.yml"))
 				Expect(err).To(BeNil())
 				Expect(string(content)).To(Equal("yaml"))
 			})
@@ -241,7 +240,7 @@ var _ = Describe("Stager", func() {
 			err := s.WriteEnvFile("ENVVAR", "value")
 			Expect(err).To(BeNil())
 
-			contents, err := ioutil.ReadFile(filepath.Join(s.DepDir(), "env", "ENVVAR"))
+			contents, err := os.ReadFile(filepath.Join(s.DepDir(), "env", "ENVVAR"))
 			Expect(err).To(BeNil())
 
 			Expect(string(contents)).To(Equal("value"))
@@ -288,14 +287,14 @@ var _ = Describe("Stager", func() {
 		var destDir string
 
 		BeforeEach(func() {
-			destDir, err = ioutil.TempDir("", "untarred-dependencies")
+			destDir, err = os.MkdirTemp("", "untarred-dependencies")
 			Expect(err).To(BeNil())
 			DeferCleanup(os.RemoveAll, destDir)
 
-			err = ioutil.WriteFile(filepath.Join(destDir, "thing1"), []byte("xxx"), 0644)
+			err = os.WriteFile(filepath.Join(destDir, "thing1"), []byte("xxx"), 0644)
 			Expect(err).To(BeNil())
 
-			err = ioutil.WriteFile(filepath.Join(destDir, "thing2"), []byte("yyy"), 0644)
+			err = os.WriteFile(filepath.Join(destDir, "thing2"), []byte("yyy"), 0644)
 			Expect(err).To(BeNil())
 		})
 
@@ -307,7 +306,7 @@ var _ = Describe("Stager", func() {
 			Expect(err).To(BeNil())
 			Expect(link).To(Equal(filepath.Join("..", "..", "..", filepath.Base(destDir), "thing1")))
 
-			data, err := ioutil.ReadFile(filepath.Join(s.DepDir(), "include", "thing1"))
+			data, err := os.ReadFile(filepath.Join(s.DepDir(), "include", "thing1"))
 			Expect(err).To(BeNil())
 			Expect(string(data)).To(Equal("xxx"))
 
@@ -315,7 +314,7 @@ var _ = Describe("Stager", func() {
 			Expect(err).To(BeNil())
 			Expect(link).To(Equal(filepath.Join("..", "..", "..", filepath.Base(destDir), "thing2")))
 
-			data, err = ioutil.ReadFile(filepath.Join(s.DepDir(), "include", "thing2"))
+			data, err = os.ReadFile(filepath.Join(s.DepDir(), "include", "thing2"))
 			Expect(err).To(BeNil())
 			Expect(string(data)).To(Equal("yyy"))
 		})
@@ -370,7 +369,7 @@ var _ = Describe("Stager", func() {
 			})
 
 			It("the script has the correct contents", func() {
-				data, err := ioutil.ReadFile(profileDScript)
+				data, err := os.ReadFile(profileDScript)
 				Expect(err).To(BeNil())
 
 				Expect(data).To(Equal([]byte("used the dir")))
@@ -395,7 +394,7 @@ var _ = Describe("Stager", func() {
 		})
 
 		It("the script has the correct contents", func() {
-			data, err := ioutil.ReadFile(profileDScript)
+			data, err := os.ReadFile(profileDScript)
 			Expect(err).To(BeNil())
 
 			Expect(data).To(Equal([]byte("made the dir")))
@@ -425,22 +424,22 @@ var _ = Describe("Stager", func() {
 			err = os.MkdirAll(filepath.Join(depsDir, "05", "env"), 0755)
 			Expect(err).To(BeNil())
 
-			err = ioutil.WriteFile(filepath.Join(depsDir, "05", "env", "ENV_VAR"), []byte("value"), 0644)
+			err = os.WriteFile(filepath.Join(depsDir, "05", "env", "ENV_VAR"), []byte("value"), 0644)
 			Expect(err).To(BeNil())
 
 			err = os.MkdirAll(filepath.Join(depsDir, "00", "profile.d"), 0755)
 			Expect(err).To(BeNil())
 
-			err = ioutil.WriteFile(filepath.Join(depsDir, "00", "profile.d", "supplied-script.sh"), []byte("first"), 0644)
+			err = os.WriteFile(filepath.Join(depsDir, "00", "profile.d", "supplied-script.sh"), []byte("first"), 0644)
 			Expect(err).To(BeNil())
 
 			err = os.MkdirAll(filepath.Join(depsDir, "01", "profile.d"), 0755)
 			Expect(err).To(BeNil())
 
-			err = ioutil.WriteFile(filepath.Join(depsDir, "01", "profile.d", "supplied-script.sh"), []byte("second"), 0644)
+			err = os.WriteFile(filepath.Join(depsDir, "01", "profile.d", "supplied-script.sh"), []byte("second"), 0644)
 			Expect(err).To(BeNil())
 
-			err = ioutil.WriteFile(filepath.Join(depsDir, "some-file.yml"), []byte("things"), 0644)
+			err = os.WriteFile(filepath.Join(depsDir, "some-file.yml"), []byte("things"), 0644)
 			Expect(err).To(BeNil())
 		})
 
@@ -610,11 +609,11 @@ var _ = Describe("Stager", func() {
 				Expect(err).To(BeNil())
 
 				if runtime.GOOS == "windows" {
-					contents, err := ioutil.ReadFile(filepath.Join(profileDir, "000_multi-supply.bat"))
+					contents, err := os.ReadFile(filepath.Join(profileDir, "000_multi-supply.bat"))
 					Expect(err).To(BeNil())
 					Expect(string(contents)).To(ContainSubstring(`set PATH=%DEPS_DIR%\01\bin;%DEPS_DIR%\00\bin;%PATH%`))
 				} else {
-					contents, err := ioutil.ReadFile(filepath.Join(profileDir, "000_multi-supply.sh"))
+					contents, err := os.ReadFile(filepath.Join(profileDir, "000_multi-supply.sh"))
 					Expect(err).To(BeNil())
 					Expect(string(contents)).To(ContainSubstring(`export LIBRARY_PATH=$DEPS_DIR/02/lib:$DEPS_DIR/01/lib$([[ ! -z "${LIBRARY_PATH:-}" ]] && echo ":$LIBRARY_PATH")`))
 					Expect(string(contents)).To(ContainSubstring(`export LD_LIBRARY_PATH=$DEPS_DIR/02/lib:$DEPS_DIR/01/lib$([[ ! -z "${LD_LIBRARY_PATH:-}" ]] && echo ":$LD_LIBRARY_PATH")`))
@@ -626,12 +625,12 @@ var _ = Describe("Stager", func() {
 				err = s.SetLaunchEnvironment()
 				Expect(err).To(BeNil())
 
-				contents, err := ioutil.ReadFile(filepath.Join(profileDir, "00_supplied-script.sh"))
+				contents, err := os.ReadFile(filepath.Join(profileDir, "00_supplied-script.sh"))
 				Expect(err).To(BeNil())
 
 				Expect(string(contents)).To(Equal("first"))
 
-				contents, err = ioutil.ReadFile(filepath.Join(profileDir, "01_supplied-script.sh"))
+				contents, err = os.ReadFile(filepath.Join(profileDir, "01_supplied-script.sh"))
 				Expect(err).To(BeNil())
 
 				Expect(string(contents)).To(Equal("second"))

--- a/util.go
+++ b/util.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -22,17 +21,13 @@ import (
 	backoff "github.com/cenkalti/backoff/v4"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 func MoveDirectory(srcDir, destDir string) error {
 	destExists, _ := FileExists(destDir)
 	if !destExists {
 		return os.Rename(srcDir, destDir)
 	}
 
-	files, err := ioutil.ReadDir(srcDir)
+	files, err := os.ReadDir(srcDir)
 	if err != nil {
 		return err
 	}
@@ -43,7 +38,7 @@ func MoveDirectory(srcDir, destDir string) error {
 		if exists, err := FileExists(dest); err != nil {
 			return err
 		} else if !exists {
-			if m := f.Mode(); m&os.ModeSymlink != 0 {
+			if m := f.Type(); m&os.ModeSymlink != 0 {
 				if err = moveSymlinks(src, dest); err != nil {
 					return err
 				}
@@ -69,7 +64,7 @@ func CopyDirectory(srcDir, destDir string) error {
 		return errors.New("destination dir must exist")
 	}
 
-	files, err := ioutil.ReadDir(srcDir)
+	files, err := os.ReadDir(srcDir)
 	if err != nil {
 		return err
 	}
@@ -78,12 +73,16 @@ func CopyDirectory(srcDir, destDir string) error {
 		src := filepath.Join(srcDir, f.Name())
 		dest := filepath.Join(destDir, f.Name())
 
-		if m := f.Mode(); m&os.ModeSymlink != 0 {
+		if m := f.Type(); m&os.ModeSymlink != 0 {
 			if err = moveSymlinks(src, dest); err != nil {
 				return err
 			}
 		} else if f.IsDir() {
-			err = os.MkdirAll(dest, f.Mode())
+			fi, err := f.Info()
+			if err != nil {
+				return err
+			}
+			err = os.MkdirAll(dest, fi.Mode())
 			if err != nil {
 				return err
 			}
@@ -96,7 +95,13 @@ func CopyDirectory(srcDir, destDir string) error {
 				return err
 			}
 
-			err = writeToFile(rc, dest, f.Mode())
+			fi, err := f.Info()
+			if err != nil {
+				rc.Close()
+				return err
+			}
+
+			err = writeToFile(rc, dest, fi.Mode())
 			if err != nil {
 				rc.Close()
 				return err
@@ -500,7 +505,7 @@ func filterURI(rawURL string) (string, error) {
 }
 
 func CheckSha256(filePath, expectedSha256 string) error {
-	content, err := ioutil.ReadFile(filePath)
+	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return err
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -1,7 +1,6 @@
 package libbuildpack_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -21,7 +20,7 @@ var _ = Describe("Util", func() {
 			fileInfo os.FileInfo
 		)
 		BeforeEach(func() {
-			tmpdir, err = ioutil.TempDir("", "exploded")
+			tmpdir, err = os.MkdirTemp("", "exploded")
 			Expect(err).To(BeNil())
 			DeferCleanup(os.RemoveAll, tmpdir)
 		})
@@ -32,7 +31,7 @@ var _ = Describe("Util", func() {
 				Expect(err).To(BeNil())
 
 				Expect(filepath.Join(tmpdir, "root.txt")).To(BeAnExistingFile())
-				Expect(ioutil.ReadFile(filepath.Join(tmpdir, "root.txt"))).To(Equal([]byte("root\n")))
+				Expect(os.ReadFile(filepath.Join(tmpdir, "root.txt"))).To(Equal([]byte("root\n")))
 			})
 
 			It("extracts a nested file", func() {
@@ -40,7 +39,7 @@ var _ = Describe("Util", func() {
 				Expect(err).To(BeNil())
 
 				Expect(filepath.Join(tmpdir, "thing", "bin", "file2.exe")).To(BeAnExistingFile())
-				Expect(ioutil.ReadFile(filepath.Join(tmpdir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
+				Expect(os.ReadFile(filepath.Join(tmpdir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
 			})
 
 			It("preserves the file mode", func() {
@@ -93,7 +92,7 @@ var _ = Describe("Util", func() {
 			err    error
 		)
 		BeforeEach(func() {
-			tmpdir, err = ioutil.TempDir("", "exploded")
+			tmpdir, err = os.MkdirTemp("", "exploded")
 			Expect(err).To(BeNil())
 			DeferCleanup(os.RemoveAll, tmpdir)
 		})
@@ -117,7 +116,7 @@ var _ = Describe("Util", func() {
 				Expect(filepath.Join(tmpdir, "root.txt")).ToNot(BeAnExistingFile())
 				// thing/bin/file2.exe should become bin/file2.exe
 				Expect(filepath.Join(tmpdir, "bin", "file2.exe")).To(BeAnExistingFile())
-				Expect(ioutil.ReadFile(filepath.Join(tmpdir, "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
+				Expect(os.ReadFile(filepath.Join(tmpdir, "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
 			})
 		})
 	})
@@ -171,7 +170,7 @@ var _ = Describe("Util", func() {
 			fileInfo os.FileInfo
 		)
 		BeforeEach(func() {
-			tmpdir, err = ioutil.TempDir("", "exploded")
+			tmpdir, err = os.MkdirTemp("", "exploded")
 			Expect(err).To(BeNil())
 			DeferCleanup(os.RemoveAll, tmpdir)
 		})
@@ -182,16 +181,18 @@ var _ = Describe("Util", func() {
 
 				innerDir := filepath.Join(tmpdir, "innerDir")
 				Expect(innerDir).To(BeADirectory())
-				files, err := ioutil.ReadDir(innerDir)
+				files, err := os.ReadDir(innerDir)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(files).NotTo(BeEmpty())
 				for _, f := range files {
-					Expect(int(f.Size())).NotTo(Equal(0))
+					fi, err := f.Info()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(int(fi.Size())).NotTo(Equal(0))
 				}
 
 				nestedFile := filepath.Join(innerDir, "inner_file.txt")
 				Expect(nestedFile).To(BeAnExistingFile())
-				contents, err := ioutil.ReadFile(nestedFile)
+				contents, err := os.ReadFile(nestedFile)
 				Expect(contents).To(ContainSubstring("simple inner file"))
 
 				symFile := filepath.Join(tmpdir, "innerDir", "softlink.txt")
@@ -204,7 +205,7 @@ var _ = Describe("Util", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					if !info.IsDir() {
-						contents, err := ioutil.ReadFile(path)
+						contents, err := os.ReadFile(path)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(contents).NotTo(BeEmpty())
 					}
@@ -220,7 +221,7 @@ var _ = Describe("Util", func() {
 				Expect(err).To(BeNil())
 
 				Expect(filepath.Join(tmpdir, "root.txt")).To(BeAnExistingFile())
-				Expect(ioutil.ReadFile(filepath.Join(tmpdir, "root.txt"))).To(Equal([]byte("root\n")))
+				Expect(os.ReadFile(filepath.Join(tmpdir, "root.txt"))).To(Equal([]byte("root\n")))
 			})
 
 			It("extracts a nested file", func() {
@@ -228,7 +229,7 @@ var _ = Describe("Util", func() {
 				Expect(err).To(BeNil())
 
 				Expect(filepath.Join(tmpdir, "thing", "bin", "file2.exe")).To(BeAnExistingFile())
-				Expect(ioutil.ReadFile(filepath.Join(tmpdir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
+				Expect(os.ReadFile(filepath.Join(tmpdir, "thing", "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
 			})
 
 			It("preserves the file mode", func() {
@@ -251,7 +252,7 @@ var _ = Describe("Util", func() {
 
 				path := filepath.Join(tmpdir, "other", "file.txt")
 				Expect(path).To(BeAnExistingFile())
-				Expect(ioutil.ReadFile(path)).To(Equal([]byte("content\n")))
+				Expect(os.ReadFile(path)).To(Equal([]byte("content\n")))
 
 				fi, err := os.Lstat(path)
 				Expect(err).To(BeNil())
@@ -291,7 +292,7 @@ var _ = Describe("Util", func() {
 			err    error
 		)
 		BeforeEach(func() {
-			tmpdir, err = ioutil.TempDir("", "exploded")
+			tmpdir, err = os.MkdirTemp("", "exploded")
 			Expect(err).To(BeNil())
 			DeferCleanup(os.RemoveAll, tmpdir)
 		})
@@ -315,7 +316,7 @@ var _ = Describe("Util", func() {
 				Expect(filepath.Join(tmpdir, "root.txt")).ToNot(BeAnExistingFile())
 				// thing/bin/file2.exe should become bin/file2.exe
 				Expect(filepath.Join(tmpdir, "bin", "file2.exe")).To(BeAnExistingFile())
-				Expect(ioutil.ReadFile(filepath.Join(tmpdir, "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
+				Expect(os.ReadFile(filepath.Join(tmpdir, "bin", "file2.exe"))).To(Equal([]byte("progam2\n")))
 			})
 		})
 	})
@@ -326,7 +327,7 @@ var _ = Describe("Util", func() {
 			err    error
 		)
 		BeforeEach(func() {
-			tmpdir, err = ioutil.TempDir("", "exploded")
+			tmpdir, err = os.MkdirTemp("", "exploded")
 			Expect(err).To(BeNil())
 			DeferCleanup(os.RemoveAll, tmpdir)
 		})
@@ -354,7 +355,7 @@ var _ = Describe("Util", func() {
 			var fh *os.File
 			sourceFile := "fixtures/source.txt"
 
-			tmpdir, err = ioutil.TempDir("", "copy")
+			tmpdir, err = os.MkdirTemp("", "copy")
 			Expect(err).To(BeNil())
 
 			fileInfo, err = os.Stat(sourceFile)
@@ -395,7 +396,7 @@ var _ = Describe("Util", func() {
 				Expect(err).To(BeNil())
 
 				Expect(filepath.Join(tmpdir, "out.txt")).To(BeAnExistingFile())
-				Expect(ioutil.ReadFile(filepath.Join(tmpdir, "out.txt"))).To(Equal([]byte("a file\n")))
+				Expect(os.ReadFile(filepath.Join(tmpdir, "out.txt"))).To(Equal([]byte("a file\n")))
 			})
 
 			It("preserves the file mode", func() {
@@ -428,7 +429,7 @@ var _ = Describe("Util", func() {
 		)
 
 		BeforeEach(func() {
-			destDir, err = ioutil.TempDir("", "destDir")
+			destDir, err = os.MkdirTemp("", "destDir")
 			Expect(err).To(BeNil())
 		})
 
@@ -473,9 +474,9 @@ var _ = Describe("Util", func() {
 		)
 
 		BeforeEach(func() {
-			srcDir, err = ioutil.TempDir("", "dir1")
+			srcDir, err = os.MkdirTemp("", "dir1")
 			Expect(err).ToNot(HaveOccurred())
-			destDir, err = ioutil.TempDir("", "")
+			destDir, err = os.MkdirTemp("", "")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -498,14 +499,14 @@ var _ = Describe("Util", func() {
 					innerDestDir := filepath.Join(destDir, "inner_dir")
 					Expect(os.MkdirAll(innerDir, 0777)).To(Succeed())
 					Expect(os.MkdirAll(innerDestDir, 0777)).To(Succeed())
-					Expect(ioutil.WriteFile(filepath.Join(innerDir, "test_file"), []byte("contentsA"), 0777)).To(Succeed())
-					Expect(ioutil.WriteFile(filepath.Join(innerDestDir, "test_file"), []byte("contentsB"), 0777)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(innerDir, "test_file"), []byte("contentsA"), 0777)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(innerDestDir, "test_file"), []byte("contentsB"), 0777)).To(Succeed())
 					Expect(os.MkdirAll(innerDir, os.ModePerm)).ToNot(HaveOccurred())
 					Expect(libbuildpack.MoveDirectory(srcDir, destDir)).To(Succeed())
 					Expect(innerDestDir).To(BeADirectory())
 					destFile := filepath.Join(innerDestDir, "test_file")
 					Expect(destFile).To(BeAnExistingFile())
-					contents, err := ioutil.ReadFile(destFile)
+					contents, err := os.ReadFile(destFile)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(string(contents)).To(ContainSubstring("contentsB"))
 				})
@@ -521,7 +522,7 @@ var _ = Describe("Util", func() {
 			)
 
 			BeforeEach(func() {
-				dir, err = ioutil.TempDir("", "file.exists")
+				dir, err = os.MkdirTemp("", "file.exists")
 				Expect(err).To(BeNil())
 				DeferCleanup(os.RemoveAll, dir)
 			})

--- a/yaml.go
+++ b/yaml.go
@@ -2,7 +2,7 @@ package libbuildpack
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -15,7 +15,7 @@ func NewYAML() *YAML {
 }
 
 func (y *YAML) Load(file string, obj interface{}) error {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -1,7 +1,6 @@
 package libbuildpack_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -18,7 +17,7 @@ var _ = Describe("YAML", func() {
 	)
 
 	BeforeEach(func() {
-		tmpDir, err = ioutil.TempDir("", "yaml")
+		tmpDir, err = os.MkdirTemp("", "yaml")
 		Expect(err).To(BeNil())
 		DeferCleanup(os.RemoveAll, tmpDir)
 
@@ -28,7 +27,7 @@ var _ = Describe("YAML", func() {
 	Describe("Load", func() {
 		Context("file is valid yaml", func() {
 			BeforeEach(func() {
-				ioutil.WriteFile(filepath.Join(tmpDir, "valid.yml"), []byte("key: value"), 0666)
+				os.WriteFile(filepath.Join(tmpDir, "valid.yml"), []byte("key: value"), 0666)
 			})
 			It("returns an error", func() {
 				obj := make(map[string]string)
@@ -41,7 +40,7 @@ var _ = Describe("YAML", func() {
 
 		Context("file is NOT valid yaml", func() {
 			BeforeEach(func() {
-				ioutil.WriteFile(filepath.Join(tmpDir, "invalid.yml"), []byte("not valid yml"), 0666)
+				os.WriteFile(filepath.Join(tmpDir, "invalid.yml"), []byte("not valid yml"), 0666)
 			})
 			It("returns an error", func() {
 				obj := make(map[string]string)
@@ -68,7 +67,7 @@ var _ = Describe("YAML", func() {
 				err = yaml.Write(filepath.Join(tmpDir, "file.yml"), obj)
 				Expect(err).To(BeNil())
 
-				Expect(ioutil.ReadFile(filepath.Join(tmpDir, "file.yml"))).To(Equal([]byte("key: val\n")))
+				Expect(os.ReadFile(filepath.Join(tmpDir, "file.yml"))).To(Equal([]byte("key: val\n")))
 			})
 		})
 
@@ -80,7 +79,7 @@ var _ = Describe("YAML", func() {
 				err = yaml.Write(filepath.Join(tmpDir, "extradir", "file.yml"), obj)
 				Expect(err).To(BeNil())
 
-				Expect(ioutil.ReadFile(filepath.Join(tmpDir, "extradir", "file.yml"))).To(Equal([]byte("key: val\n")))
+				Expect(os.ReadFile(filepath.Join(tmpDir, "extradir", "file.yml"))).To(Equal([]byte("key: val\n")))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

- Replaces all deprecated `io/ioutil` function calls with their modern `os.*` / `io.*` equivalents (available since Go 1.16, deprecated since Go 1.16)
- Removes deprecated `rand.Seed()` calls (deprecated since Go 1.20); `SeedRandom()` in cutlass helpers is preserved as a no-op for API compatibility
- All 35 first-party source files updated; vendor directory untouched

## Replacements

| Deprecated | Modern |
|---|---|
| `ioutil.ReadFile()` | `os.ReadFile()` |
| `ioutil.WriteFile()` | `os.WriteFile()` |
| `ioutil.ReadDir()` | `os.ReadDir()` |
| `ioutil.TempDir()` | `os.MkdirTemp()` |
| `ioutil.TempFile()` | `os.CreateTemp()` |
| `ioutil.ReadAll()` | `io.ReadAll()` |
| `ioutil.Discard` | `io.Discard` |
| `rand.Seed(time.Now().UnixNano())` | removed |

## Testing

`go build ./...` and `go test ./...` both pass cleanly.